### PR TITLE
feat: voucher parameter

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -45,6 +45,7 @@ const showMenu = async function() {
         choices: [
             {name: 'Carga de llaves', value: 'loadKey'},
             {name: 'Realizar una venta', value: 'sale'},
+            {name: 'Realizar una venta Multicódigo', value: 'multicodeSale'},
             {name: 'Realizar una devolución', value: 'refund'},
             {name: 'Ver detalle de ventas', value: 'salesDetail'},
             {name: 'Cerrar sesión POS', value: 'close'},
@@ -93,6 +94,10 @@ const executeOption = async function(option) {
             
         case 'sale':
             await saleOperation()
+            break;
+
+        case 'multicodeSale':
+            await multicodeSaleOperation()
             break;
 
         case 'refund':
@@ -207,21 +212,13 @@ const saleOperation = async function() {
     const intermediateMessages = await select({
     message: 'Recibir mensajes intermedios?',
     choices: [
-        {
-            name: 'Si',
-            value: true,
-            description: 'Se recibirán mensajes intermedios durante la venta.'
-        },
-        {
-            name: 'No',
-            value: false,
-            description: 'Solo se recibe la respuesta de la venta.'
-        }
+            { name: 'Si', value: true },
+            { name: 'No', value: false }
         ]
     });
 
     const printVoucher = await select({
-        message: '¿Imprimir voucher en la respuesta?',
+        message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
             {
                 name: 'Si',
@@ -243,7 +240,52 @@ const saleOperation = async function() {
     .catch(error => {
         console.log('Error en la venta:', error)
     });
+}
 
+const multicodeSaleOperation = async function() {
+    const saleAmount = await input({
+        message: 'Ingrese el monto de la venta (sin vuelto):',
+        default: '1000'
+    });
+
+    const cashbackAmount = await input({
+        message: 'Ingrese el monto del vuelto (0 si no aplica):',
+        default: '0'
+    });
+
+    const ticket = await input({
+        message: 'Ingrese el ticket de la venta:',
+        default: 'MULTI123'
+    });
+
+    const commerceCode = await input({
+        message: 'Ingrese el código de comercio (dejar en 0 si no aplica):',
+        default: '0'
+    });
+
+    const intermediateMessages = await select({
+        message: 'Recibir mensajes intermedios?',
+        choices: [
+            { name: 'Si', value: true },
+            { name: 'No', value: false }
+        ]
+    });
+
+    const printVoucher = await select({
+        message: '¿Desea el voucher en la respuesta JSON?',
+        choices: [
+            { name: 'Si', value: true },
+            { name: 'No', value: false }
+        ]
+    });
+
+    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printVoucher, (intermediateResponse) => console.log(intermediateResponse))
+    .then(response => {
+        console.log('Respuesta de la venta multicódigo:', response);
+    })
+    .catch(error => {
+        console.log('Error en la venta multicódigo:', error)
+    });
 }
 
 const refundOperation = async function() {

--- a/examples/index.js
+++ b/examples/index.js
@@ -220,6 +220,22 @@ const saleOperation = async function() {
         ]
     });
 
+    const printVoucher = await select({
+        message: '¿Imprimir Voucher en la respuesta?',
+        choices: [
+            {
+                name: 'Si',
+                value: true,
+                description: 'Se imprimirá el voucher en la respuesta' 
+            },
+            {
+                name: 'No',
+                value: false,
+                description: 'No se imprimirá el voucher en la respuesta'
+            }
+        ]
+    });
+
     await pos.sale(amount, ticket, intermediateMessages, (intermediateResponse) => console.log(intermediateResponse))
     .then(response => {
         console.log('Respuesta de la venta:', response);

--- a/examples/index.js
+++ b/examples/index.js
@@ -36,7 +36,7 @@ const showMenu = async function() {
         choices: [
             {name: 'Carga de llaves', value: 'loadKey'},
             {name: 'Realizar una venta', value: 'sale'},
-            {name: 'Realizar una venta Multicódigo', value: 'multicodeSale'},
+            {name: 'Realizar una venta multicódigo', value: 'multicodeSale'},
             {name: 'Realizar una devolución', value: 'refund'},
             {name: 'Ver detalle de ventas', value: 'salesDetail'},
             {name: 'Cerrar sesión POS', value: 'close'},
@@ -205,7 +205,7 @@ const saleOperation = async function() {
     })
 
     const intermediateMessages = await select({
-    message: 'Recibir mensajes intermedios?',
+    message: '¿Desea recibir mensajes intermedios?',
     choices: [
             { name: 'Si', value: true },
             { name: 'No', value: false }

--- a/examples/index.js
+++ b/examples/index.js
@@ -239,13 +239,8 @@ const saleOperation = async function() {
 
 const multicodeSaleOperation = async function() {
     const saleAmount = await input({
-        message: 'Ingrese el monto de la venta (sin vuelto):',
+        message: 'Ingrese el monto de la venta:',
         default: '1000'
-    });
-
-    const cashbackAmount = await input({
-        message: 'Ingrese el monto del vuelto (0 si no aplica):',
-        default: '0'
     });
 
     const ticket = await input({
@@ -265,11 +260,8 @@ const multicodeSaleOperation = async function() {
             { name: 'No', value: false }
         ]
     });
-
-    let printOnPOS = true;
     
-    if (Number.parseInt(cashbackAmount) <= 0) {
-        printOnPOS = await select({
+    const printVoucher = await select({
         message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
             {
@@ -284,9 +276,15 @@ const multicodeSaleOperation = async function() {
             }
         ]
     });
-    }
 
-    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printOnPOS, (intermediateResponse) => console.log(intermediateResponse))
+    await pos.multicodeSale(
+        saleAmount, 
+        ticket, 
+        commerceCode, 
+        intermediateMessages, 
+        printVoucher, 
+        (intermediateResponse) => console.log(intermediateResponse)
+    )
     .then(response => {
         console.log('Respuesta de la venta multicódigo:', response);
     })

--- a/examples/index.js
+++ b/examples/index.js
@@ -245,7 +245,7 @@ const multicodeSaleOperation = async function() {
 
     const ticket = await input({
         message: 'Ingrese el ticket de la venta:',
-        default: 'MULTI123'
+        default: 'MC1234'
     });
 
     const commerceCode = await input({

--- a/examples/index.js
+++ b/examples/index.js
@@ -236,7 +236,7 @@ const saleOperation = async function() {
         ]
     });
 
-    await pos.sale(amount, ticket, intermediateMessages, (intermediateResponse) => console.log(intermediateResponse))
+    await pos.sale(amount, ticket, intermediateMessages, printVoucher, (intermediateResponse) => console.log(intermediateResponse))
     .then(response => {
         console.log('Respuesta de la venta:', response);
     })

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,6 @@
 const { rawlist, input, select } = require('@inquirer/prompts')
 const Transbank = require('../index')
 
-const CLOSE_APP = 0
 const CLOSE_PORT = 1
 const PORT_OPEN = 2
 
@@ -19,10 +18,6 @@ const main = async function() {
         if(connectionOperationResult == PORT_OPEN) {
             isConnected = true
         }
-        
-        if(connectionOperationResult == CLOSE_APP) {
-            exit = true
-        }
 
         while(!exit && isConnected) {
             let option = await showMenu()
@@ -30,10 +25,6 @@ const main = async function() {
 
             if(operationResult == CLOSE_PORT) {
                 isConnected = false
-            }
-
-            if(operationResult == CLOSE_APP) {
-                exit = true
             }
         }
     }
@@ -134,7 +125,9 @@ const executeOption = async function(option) {
 
         case 'exit':
             console.log('Saliendo...')
-            return CLOSE_APP;
+            pos.disconnect();
+            process.exit(0);
+            break;
 
         default:
             console.log('Opción no válida. Inténtalo de nuevo.')
@@ -174,7 +167,9 @@ const executeConnectionOption = async function(option) {
 
         case 'exit':
             console.log('Saliendo...')
-            return CLOSE_APP;
+            pos.disconnect();
+            process.exit(0);
+            break;
 
         default:
             console.log('Opción no válida. Inténtalo de nuevo.')
@@ -271,15 +266,29 @@ const multicodeSaleOperation = async function() {
         ]
     });
 
-    const printVoucher = await select({
+    let printOnPOS = true;
+    
+    if (parseInt(cashbackAmount) <= 0) {
+        const printOnPOS = await select({
         message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
-            { name: 'Si', value: true },
-            { name: 'No', value: false }
+            {
+                name: 'Si',
+                value: true,
+                description: 'Se imprimirá el voucher en la respuesta' 
+            },
+            {
+                name: 'No',
+                value: false,
+                description: 'El POS imprimirá el voucher'
+            }
         ]
     });
+    } else {
+        printOnPOS = true;
+    }
 
-    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printVoucher, (intermediateResponse) => console.log(intermediateResponse))
+    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printOnPOS, (intermediateResponse) => console.log(intermediateResponse)) // Usar printOnPOS
     .then(response => {
         console.log('Respuesta de la venta multicódigo:', response);
     })

--- a/examples/index.js
+++ b/examples/index.js
@@ -221,7 +221,7 @@ const saleOperation = async function() {
     });
 
     const printVoucher = await select({
-        message: '¿Imprimir Voucher en la respuesta?',
+        message: '¿Imprimir voucher en la respuesta?',
         choices: [
             {
                 name: 'Si',
@@ -231,7 +231,7 @@ const saleOperation = async function() {
             {
                 name: 'No',
                 value: false,
-                description: 'No se imprimirá el voucher en la respuesta'
+                description: 'El POS imprimirá el voucher'
             }
         ]
     });

--- a/examples/index.js
+++ b/examples/index.js
@@ -269,7 +269,7 @@ const multicodeSaleOperation = async function() {
     let printOnPOS = true;
     
     if (parseInt(cashbackAmount) <= 0) {
-        printOnPOS = await select({
+        const printOnPOS = await select({
         message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
             {

--- a/examples/index.js
+++ b/examples/index.js
@@ -286,7 +286,7 @@ const multicodeSaleOperation = async function() {
     });
     }
 
-    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printOnPOS, (intermediateResponse) => console.log(intermediateResponse)) // Usar printOnPOS
+    await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printOnPOS, (intermediateResponse) => console.log(intermediateResponse))
     .then(response => {
         console.log('Respuesta de la venta multicódigo:', response);
     })

--- a/examples/index.js
+++ b/examples/index.js
@@ -268,8 +268,8 @@ const multicodeSaleOperation = async function() {
 
     let printOnPOS = true;
     
-    if (parseInt(cashbackAmount) <= 0) {
-        const printOnPOS = await select({
+    if (Number.parseInt(cashbackAmount) <= 0) {
+        printOnPOS = await select({
         message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
             {
@@ -284,8 +284,6 @@ const multicodeSaleOperation = async function() {
             }
         ]
     });
-    } else {
-        printOnPOS = true;
     }
 
     await pos.multicodeSale(saleAmount, ticket, commerceCode, cashbackAmount, intermediateMessages, printOnPOS, (intermediateResponse) => console.log(intermediateResponse)) // Usar printOnPOS

--- a/examples/index.js
+++ b/examples/index.js
@@ -294,7 +294,7 @@ const multicodeSaleOperation = async function() {
 }
 
 const refundOperation = async function() {
-    const operationId = await editor({
+    const operationId = await input({
         message: 'Ingresa el número de operación'
     })
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -269,7 +269,7 @@ const multicodeSaleOperation = async function() {
     let printOnPOS = true;
     
     if (parseInt(cashbackAmount) <= 0) {
-        const printOnPOS = await select({
+        printOnPOS = await select({
         message: '¿Desea el voucher en la respuesta JSON?',
         choices: [
             {

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -276,39 +276,33 @@ module.exports = class POSBase extends EventEmitter {
                 reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds`))
             }, this.posTimeout)
 
-            const responseListener = (data) => {
-                if (this.itsAnACK(data)) {
-                    if (typeof this.ackCallback === "function") {
-                        this.ackCallback(data);
-                    }
-                    return;
+            // Wait for the response and fullfill the Promise
+            this.responseCallback = (data) => {
+                clearTimeout(responseTimeout)
+                let response = data
+                if (this.responseAsString) {
+                    response = data.toString().slice(1, -2)
                 }
-
-                let responseString = data.toString().slice(1, -2);
-                let functionCode = data.toString().slice(1, 5);
-
-                this.port.write(Buffer.from([ACK]));
-                this.debug(`OUT --> ${this.bufferToPrintableString([ACK])}`);
-
-                if (functionCode === "0900" || functionCode === "0261") {
-                    if (typeof callback === "function"){
-                        if (functionCode === "0900") {
-                            callback(this.intermediateResponse(responseString), data);
-                        } else { 
-                            callback(responseString, data);
-                        }
-                    }
-                    return;
-                }
-
-                clearTimeout(responseTimeout);
-                this.waiting = false;
-                this.parser.off("data", responseListener);
+                let functionCode = data.toString().slice(1, 5)
                 
-                resolve(responseString, data);
-            };
+                if (functionCode === "0900") { // Sale status messages
+                    if (typeof callback === "function"){
+                        callback(this.intermediateResponse(response), data)
+                    }
+                    return
+                }
+                if (functionCode === "0261") {
+                    if (typeof callback === "function"){
+                        callback(response, data)
+                    }
+                    return
+                }
 
-            this.parser.on("data", responseListener);
+                this.waiting = false
+
+                resolve(response, data)
+            }
+
         })
     }
 

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -276,33 +276,39 @@ module.exports = class POSBase extends EventEmitter {
                 reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds`))
             }, this.posTimeout)
 
-            // Wait for the response and fullfill the Promise
-            this.responseCallback = (data) => {
-                clearTimeout(responseTimeout)
-                let response = data
-                if (this.responseAsString) {
-                    response = data.toString().slice(1, -2)
+            const responseListener = (data) => {
+                if (this.itsAnACK(data)) {
+                    if (typeof this.ackCallback === "function") {
+                        this.ackCallback(data);
+                    }
+                    return;
                 }
-                let functionCode = data.toString().slice(1, 5)
+
+                let responseString = data.toString().slice(1, -2);
+                let functionCode = data.toString().slice(1, 5);
+
+                this.port.write(Buffer.from([ACK]));
+                this.debug(`OUT --> ${this.bufferToPrintableString([ACK])}`);
+
+                if (functionCode === "0900" || functionCode === "0261") {
+                    if (typeof callback === "function"){
+                        if (functionCode === "0900") {
+                            callback(this.intermediateResponse(responseString), data);
+                        } else { 
+                            callback(responseString, data);
+                        }
+                    }
+                    return;
+                }
+
+                clearTimeout(responseTimeout);
+                this.waiting = false;
+                this.parser.off("data", responseListener);
                 
-                if (functionCode === "0900") { // Sale status messages
-                    if (typeof callback === "function"){
-                        callback(this.intermediateResponse(response), data)
-                    }
-                    return
-                }
-                if (functionCode === "0261") {
-                    if (typeof callback === "function"){
-                        callback(response, data)
-                    }
-                    return
-                }
+                resolve(responseString, data);
+            };
 
-                this.waiting = false
-
-                resolve(response, data)
-            }
-
+            this.parser.on("data", responseListener);
         })
     }
 

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,5 +1,4 @@
 const POSBase = require('./PosBase')
-const FUNCTION_CODE_MULTICODE_SALE = '0271';
 const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
 const FUNCTION_CODE_SALE_REQUEST = '0200';
 
@@ -15,12 +14,12 @@ module.exports = class POSIntegrado extends POSBase {
         return this.send("0500||").then((data) => {
             let chunks = data.split("|")
             return {
-                functionCode: parseInt(chunks[0]),
-                responseCode: parseInt(chunks[1]),
-                commerceCode: parseInt(chunks[2]),
+                functionCode: Number.parseInt(chunks[0]),
+                responseCode: Number.parseInt(chunks[1]),
+                commerceCode: Number.parseInt(chunks[2]),
                 terminalId: chunks[3],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: parseInt(chunks[1])===0
+                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+                successful: Number.parseInt(chunks[1])===0
             }
         })
     }
@@ -40,12 +39,12 @@ module.exports = class POSIntegrado extends POSBase {
         return this.send("0700||").then((data) => {
             let chunks = data.split("|")
             return {
-                functionCode: parseInt(chunks[0]),
-                responseCode: parseInt(chunks[1]),
-                txCount: parseInt(chunks[2]),
-                txTotal: parseInt(chunks[3]),
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: parseInt(chunks[1])===0
+                functionCode: Number.parseInt(chunks[0]),
+                responseCode: Number.parseInt(chunks[1]),
+                txCount: Number.parseInt(chunks[2]),
+                txTotal: Number.parseInt(chunks[3]),
+                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+                successful: Number.parseInt(chunks[1])===0
             }
         })
     }
@@ -100,14 +99,14 @@ module.exports = class POSIntegrado extends POSBase {
         return this.send(`1200|${operationId}|`).then((data) => {
             let chunks = data.split("|")
             return {
-                functionCode: parseInt(chunks[0]),
-                responseCode: parseInt(chunks[1]),
-                commerceCode: parseInt(chunks[2]),
+                functionCode: Number.parseInt(chunks[0]),
+                responseCode: Number.parseInt(chunks[1]),
+                commerceCode: Number.parseInt(chunks[2]),
                 terminalId: chunks[3],
                 authorizationCode: chunks[4].trim(),
                 operationId: chunks[5],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: parseInt(chunks[1])===0
+                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+                successful: Number.parseInt(chunks[1])===0
             }
         })
     }
@@ -153,16 +152,16 @@ module.exports = class POSIntegrado extends POSBase {
         let chunks = payload.split("|")
         let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
         return {
-            functionCode: parseInt(chunks[0]),
-            responseCode: parseInt(chunks[1]),
-            commerceCode: parseInt(chunks[2]),
+            functionCode: Number.parseInt(chunks[0]),
+            responseCode: Number.parseInt(chunks[1]),
+            commerceCode: Number.parseInt(chunks[2]),
             terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-            successful: parseInt(chunks[1])===0,
+            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+            successful: Number.parseInt(chunks[1])===0,
             ticket: chunks[4],
             authorizationCode: authorizationCode,
             amount: chunks[6],
-            last4Digits: parseInt(chunks[7]),
+            last4Digits: Number.parseInt(chunks[7]),
             operationNumber: chunks[8],
             cardType: chunks[9],
             accountingDate: chunks[10],
@@ -171,7 +170,7 @@ module.exports = class POSIntegrado extends POSBase {
             realDate: chunks[13],
             realTime: chunks[14],
             employeeId: chunks[15],
-            tip: parseInt(chunks[16]),
+            tip: Number.parseInt(chunks[16]),
             feeAmount: (chunks[16]),
             feeNumber: (chunks[17])
         }
@@ -181,18 +180,18 @@ module.exports = class POSIntegrado extends POSBase {
         let chunks = payload.split("|")
         let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
         let response = {
-            functionCode: parseInt(chunks[0]),
-            responseCode: parseInt(chunks[1]),
-            commerceCode: parseInt(chunks[2]),
+            functionCode: Number.parseInt(chunks[0]),
+            responseCode: Number.parseInt(chunks[1]),
+            commerceCode: Number.parseInt(chunks[2]),
             terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-            successful: parseInt(chunks[1])===0,
+            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+            successful: Number.parseInt(chunks[1])===0,
             ticket: chunks[4],
             authorizationCode: authorizationCode,
-            amount: parseInt(chunks[6]),
+            amount: Number.parseInt(chunks[6]),
             sharesNumber: chunks[7],
             sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
+            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
             operationNumber: chunks[10],
             cardType: chunks[11],
             accountingDate: chunks[12],
@@ -202,7 +201,6 @@ module.exports = class POSIntegrado extends POSBase {
             realTime: chunks[16],
             employeeId: chunks[17],
             tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
-            commerceCodeSent: null,
             voucher: null
         };
 

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -131,7 +131,7 @@ module.exports = class POSIntegrado extends POSBase {
 
     refund(operationId) {
         if (typeof operationId === "undefined") {
-            throw new Error("Operation ID not provided when calling refund method.");
+            throw new TypeError("Operation ID not provided when calling refund method.");
         }
 
         operationId = operationId.toString().slice(0, 6);

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -127,11 +127,11 @@ module.exports = class POSIntegrado extends POSBase {
         const voucherPrintCommand = printOnPOS ? "1" : "0";
         
         const actualCommerceCode = commerceCode === null ? '0' : commerceCode.toString().padStart(12, '0');
-        const actualCashbackAmount = numericCashback; // Guardamos el valor numérico
+        const actualCashbackAmount = numericCashback;
         
         const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
 
-        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`; // Usar actualCommerceCode en el comando
+        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`;
 
         return this.send(command, true, callback).then((data) => {
             const parsedResponse = this.saleResponse(data);

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -164,9 +164,9 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     saleResponse(payload) {
-        let chunks = payload.split("|")
-        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-        let response = {
+    let chunks = payload.split("|")
+    let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+    let response = {
             functionCode: parseInt(chunks[0]),
             responseCode: parseInt(chunks[1]),
             commerceCode: parseInt(chunks[2]),
@@ -187,7 +187,8 @@ module.exports = class POSIntegrado extends POSBase {
             realDate: chunks[15],
             realTime: chunks[16],
             employeeId: chunks[17],
-            tip: chunks[18] !== '' ? parseInt(chunks[18]) : null
+            tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
+            voucher: chunks[19]?.match(/.{1,40}/g)
         };
         if (chunks[0] === FUNCTION_CODE_MULTICODE_SALE) {
             response.change = chunks[20];

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,22 +117,31 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
+    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, printOnPOS = false, callback = null) {
         const numericCashback = parseInt(cashbackAmount) || 0;
         const commandCode = numericCashback > 0 ? "0280" : "0270";
 
         const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
         const ticketStr = ticket.toString().padStart(6, "0").slice(0, 6);
         const statusStr = sendStatus ? "1" : "0";
-        const voucherStr = (numericCashback > 0) ? "0" : (sendVoucher ? "1" : "0");
-        const commerceCodeStr = (commerceCode === null ? '0' : commerceCode.toString()).padStart(12, '0');
+        const voucherPrintCommand = printOnPOS ? "1" : "0";
+        
+        const actualCommerceCode = commerceCode === null ? '0' : commerceCode.toString().padStart(12, '0');
+        const actualCashbackAmount = numericCashback; // Guardamos el valor numérico
         
         const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
 
-        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherStr}|${statusStr}|${commerceCodeStr}`;
+        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`; // Usar actualCommerceCode en el comando
 
         return this.send(command, true, callback).then((data) => {
-            return this.saleResponse(data);
+            const parsedResponse = this.saleResponse(data);
+            
+            if (parsedResponse.functionCode.toString() === '281') {
+                parsedResponse.cashbackSent = actualCashbackAmount;
+                parsedResponse.commerceCodeSent = actualCommerceCode;
+            }
+
+            return parsedResponse;
         });
     }
 
@@ -171,49 +180,44 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     saleResponse(payload) {
-    let chunks = payload.split("|")
-        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-        let response = {
-            functionCode: parseInt(chunks[0]),
-            responseCode: parseInt(chunks[1]),
-            commerceCode: parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-            successful: parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
-        };
+        let chunks = payload.split("|")
+            let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+            let response = {
+                functionCode: parseInt(chunks[0]),
+                responseCode: parseInt(chunks[1]),
+                commerceCode: parseInt(chunks[2]),
+                terminalId: chunks[3],
+                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+                successful: parseInt(chunks[1])===0,
+                ticket: chunks[4],
+                authorizationCode: authorizationCode,
+                amount: parseInt(chunks[6]),
+                sharesNumber: chunks[7],
+                sharesAmount: chunks[8],
+                last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
+                operationNumber: chunks[10],
+                cardType: chunks[11],
+                accountingDate: chunks[12],
+                accountNumber: chunks[13],
+                cardBrand: chunks[14],
+                realDate: chunks[15],
+                realTime: chunks[16],
+                employeeId: chunks[17],
+                tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
+            };
 
-        const functionCodeStr = chunks[0].toString();
-        
-        // El voucher puede estar en el campo 19 para ventas normales y multicódigo
-        if (chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g)
-        }
-        
-        // Campos específicos de multicódigo
-        if (functionCodeStr === '271' || functionCodeStr === '281') {
-            response.cashback = parseInt(chunks[20]) || 0;
-            response.providerCommerceCode = chunks[21]; // Usar un campo nuevo para no sobreescribir
-            if (functionCodeStr === '281') {
-                response.tip = null;
+            const functionCodeStr = response.functionCode.toString(); 
+
+            if (functionCodeStr !== '281' && chunks[19] && chunks[19].length > 1) {
+                response.voucher = chunks[19]?.match(/.{1,40}/g)
             }
-        }
-    
-    return response;
-}
+            
+            if (functionCodeStr === '271' || functionCodeStr === '281') {
+                response.cashback = parseInt(chunks[20]) || 0;
+                response.providerCommerceCode = chunks[21]; 
+            }
+        
+        return response;
+    }
 
 }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,24 +117,21 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
+    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, printOnPOS = false, callback = null) {
         const numericCashback = parseInt(cashbackAmount) || 0;
         const commandCode = numericCashback > 0 ? "0280" : "0270";
 
         const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
         const ticketStr = ticket.toString().padStart(6, "0").slice(0, 6);
         const statusStr = sendStatus ? "1" : "0";
-        const voucherStr = (numericCashback > 0) ? "0" : (sendVoucher ? "1" : "0");
+        const voucherPrintCommand = printOnPOS ? "1" : "0";
         
         const actualCommerceCode = commerceCode === null ? '0' : commerceCode.toString().padStart(12, '0');
-        const actualCashbackAmount = numericCashback;
+        const actualCashbackAmount = numericCashback; // Guardamos el valor numérico
         
         const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
 
-        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherStr}|${statusStr}|${actualCommerceCode}`;
-
-        // AÑADIR ESTA LÍNEA PARA DEPURACIÓN
-        console.log(`[DEBUG] Comando construido: ${command}`);
+        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`; // Usar actualCommerceCode en el comando
 
         return this.send(command, true, callback).then((data) => {
             const parsedResponse = this.saleResponse(data);

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -118,7 +118,7 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, printOnPOS = false, callback = null) {
-        const numericCashback = parseInt(cashbackAmount) || 0;
+        const numericCashback = Number.parseInt(cashbackAmount) || 0;
         const commandCode = numericCashback > 0 ? "0280" : "0270";
 
         const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
@@ -203,7 +203,7 @@ module.exports = class POSIntegrado extends POSBase {
                 realDate: chunks[15],
                 realTime: chunks[16],
                 employeeId: chunks[17],
-                tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
+                tip: chunks[18] === '' ? null : Number.parseInt(chunks[18])
             };
 
             const functionCodeStr = response.functionCode.toString(); 
@@ -213,7 +213,7 @@ module.exports = class POSIntegrado extends POSBase {
             }
             
             if (functionCodeStr === '271' || functionCodeStr === '281') {
-                response.cashback = parseInt(chunks[20]) || 0;
+                response.cashback = Number.parseInt(chunks[20]) || 0;
                 response.providerCommerceCode = chunks[21]; 
             }
         

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,16 +117,23 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
-        amount = amount.toString().padStart(9, "0").slice(0, 9)
-        ticket = ticket.toString().padStart(6, "0").slice(0, 6)
-        commerceCode = commerceCode === null ? '0' : commerceCode;
-        let status = sendStatus ? "1":"0"
-        let voucher = sendVoucher ? "1" : "0"
+    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
+        const numericCashback = parseInt(cashbackAmount) || 0;
+        const commandCode = numericCashback > 0 ? "0280" : "0270";
 
-        return this.send(`0270|${amount}|${ticket}||${voucher}|${status}|${commerceCode}`, true, callback).then((data) => {
-            return this.saleResponse(data)
-        })
+        const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
+        const ticketStr = ticket.toString().padStart(6, "0").slice(0, 6);
+        const statusStr = sendStatus ? "1" : "0";
+        const voucherStr = (numericCashback > 0) ? "0" : (sendVoucher ? "1" : "0");
+        const commerceCodeStr = (commerceCode === null ? '0' : commerceCode.toString()).padStart(12, '0');
+        
+        const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
+
+        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherStr}|${statusStr}|${commerceCodeStr}`;
+
+        return this.send(command, true, callback).then((data) => {
+            return this.saleResponse(data);
+        });
     }
 
     /*
@@ -165,8 +172,8 @@ module.exports = class POSIntegrado extends POSBase {
 
     saleResponse(payload) {
     let chunks = payload.split("|")
-    let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-    let response = {
+        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+        let response = {
             functionCode: parseInt(chunks[0]),
             responseCode: parseInt(chunks[1]),
             commerceCode: parseInt(chunks[2]),
@@ -188,12 +195,25 @@ module.exports = class POSIntegrado extends POSBase {
             realTime: chunks[16],
             employeeId: chunks[17],
             tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
-            voucher: chunks[19]?.match(/.{1,40}/g)
         };
-        if (chunks[0] === FUNCTION_CODE_MULTICODE_SALE) {
-            response.change = chunks[20];
-            response.commerceCode = chunks[21];
+
+        const functionCodeStr = chunks[0].toString();
+        
+        // El voucher puede estar en el campo 19 para ventas normales y multicódigo
+        if (chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g)
         }
-        return response;
-    }
+        
+        // Campos específicos de multicódigo
+        if (functionCodeStr === '271' || functionCodeStr === '281') {
+            response.cashback = parseInt(chunks[20]) || 0;
+            response.providerCommerceCode = chunks[21]; // Usar un campo nuevo para no sobreescribir
+            if (functionCodeStr === '281') {
+                response.tip = null;
+            }
+        }
+    
+    return response;
+}
+
 }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,13 +117,14 @@ module.exports = class POSIntegrado extends POSBase {
         })
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, callback = null) {
+    multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
         amount = amount.toString().padStart(9, "0").slice(0, 9)
         ticket = ticket.toString().padStart(6, "0").slice(0, 6)
         commerceCode = commerceCode === null ? '0' : commerceCode;
         let status = sendStatus ? "1":"0"
+        let voucher = sendVoucher ? "1" : "0"
 
-        return this.send(`0270|${amount}|${ticket}|||${status}|${commerceCode}`, true, callback).then((data) => {
+        return this.send(`0270|${amount}|${ticket}||${voucher}|${status}|${commerceCode}`, true, callback).then((data) => {
             return this.saleResponse(data)
         })
     }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,21 +117,24 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, printOnPOS = false, callback = null) {
+    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
         const numericCashback = parseInt(cashbackAmount) || 0;
         const commandCode = numericCashback > 0 ? "0280" : "0270";
 
         const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
         const ticketStr = ticket.toString().padStart(6, "0").slice(0, 6);
         const statusStr = sendStatus ? "1" : "0";
-        const voucherPrintCommand = printOnPOS ? "1" : "0";
+        const voucherStr = (numericCashback > 0) ? "0" : (sendVoucher ? "1" : "0");
         
         const actualCommerceCode = commerceCode === null ? '0' : commerceCode.toString().padStart(12, '0');
-        const actualCashbackAmount = numericCashback; // Guardamos el valor numérico
+        const actualCashbackAmount = numericCashback;
         
         const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
 
-        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`; // Usar actualCommerceCode en el comando
+        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherStr}|${statusStr}|${actualCommerceCode}`;
+
+        // AÑADIR ESTA LÍNEA PARA DEPURACIÓN
+        console.log(`[DEBUG] Comando construido: ${command}`);
 
         return this.send(command, true, callback).then((data) => {
             const parsedResponse = this.saleResponse(data);

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -133,7 +133,7 @@ module.exports = class POSIntegrado extends POSBase {
         const ticketStr = this.formatNumericString(ticket, 6);
         const statusStr = this.getBooleanFlag(sendStatus);
         const voucherStr = this.getBooleanFlag(sendVoucher);
-        const commerceCodeStr = commerceCode ? commerceCode.toString() : '';
+        const commerceCodeStr = this.formatNumericString(commerceCode || '0', 12);
 
         const command = `${FUNCTION_CODE_MULTICODE_SALE_REQUEST}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}|${commerceCodeStr}`;
 
@@ -239,7 +239,7 @@ module.exports = class POSIntegrado extends POSBase {
             employeeId: chunks[17],
             tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
             voucher: null,
-            commerceProviderCode: chunks[21] || null
+            providerCommerceCode: chunks[21] || null
         };
 
         if(chunks[19] && chunks[19].length > 1) {

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -107,14 +107,14 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
-        amount = amount.toString().padStart(9, "0").slice(0, 9)
-        ticket = ticket.toString().padStart(6, "0").slice(0, 6)
-        let status = sendStatus ? "1":"0"
-        let voucher = sendVoucher ? "1" : "0"
+        amount = amount.toString().padStart(9, "0").slice(0, 9);
+        ticket = ticket.toString().padStart(6, "0").slice(0, 6);
+        let status = sendStatus ? "1" : "0";
+        let voucher = sendVoucher ? "1" : "0";
 
         return this.send(`0200|${amount}|${ticket}||${voucher}|${status}`, true, callback).then((data) => {
-            return this.saleResponse(data)
-        })
+            return this.saleResponse(data);
+        });
     }
 
     multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -109,18 +109,13 @@ module.exports = class POSIntegrado extends POSBase {
 
     buildSaleCommand(functionCode, amount, ticket, sendStatus, sendVoucher, commerceCode = null) {
         const statusStr = this.getBooleanFlag(sendStatus);
+        const voucherStr = this.getBooleanFlag(sendVoucher);
+
+        let command = `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}`;
 
         if (functionCode === FUNCTION_CODE_MULTICODE_SALE_REQUEST) {
             const code = commerceCode && commerceCode !== '0' ? commerceCode : '';
-            const voucherStr = this.getBooleanFlag(sendVoucher);
-            return `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}|${code}|`;
-        }
-        
-        const voucherStr = this.getBooleanFlag(sendVoucher);
-        let command = `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}`;
-        
-        if (commerceCode !== null) {
-            command += `|${commerceCode}`;
+            command += `|${code}|`;
         }
         
         return command;

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -6,22 +6,71 @@ module.exports = class POSIntegrado extends POSBase {
 
     /*
      |--------------------------------------------------------------------------
+     | Auxiliary Methods
+     |--------------------------------------------------------------------------
+     */
+
+    formatNumericString(value, length = 9) {
+        return value.toString().padStart(length, "0").slice(0, length);
+    }
+
+    getBooleanFlag(value) {
+        return (value === true || value === 'true') ? "1" : "0";
+    }
+
+    getBaseResponse(chunks) {
+        return {
+            functionCode: Number.parseInt(chunks[0]),
+            responseCode: Number.parseInt(chunks[1]),
+            commerceCode: Number.parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+            successful: Number.parseInt(chunks[1]) === 0
+        };
+    }
+
+    getBaseSaleResponse(chunks) {
+        const baseResponse = this.getBaseResponse(chunks);
+        const authorizationCode = chunks[5]?.trim() ?? null;
+
+        return {
+            ...baseResponse,
+            ticket: chunks[4],
+            authorizationCode,
+            amount: Number.parseInt(chunks[6]),
+            sharesNumber: chunks[7],
+            sharesAmount: chunks[8],
+            last4Digits: chunks[9] === '' ? null : Number.parseInt(chunks[9]),
+            operationNumber: chunks[10],
+            cardType: chunks[11],
+            accountingDate: chunks[12],
+            accountNumber: chunks[13],
+            cardBrand: chunks[14],
+            realDate: chunks[15],
+            realTime: chunks[16],
+            employeeId: chunks[17],
+            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
+            voucher: null
+        };
+    }
+
+    addVoucherToResponse(response, chunks) {
+        if (chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g);
+        }
+        return response;
+    }
+
+    /*
+     |--------------------------------------------------------------------------
      | POS Methods
      |--------------------------------------------------------------------------
      */
 
     closeDay() {
         return this.send("0500||").then((data) => {
-            let chunks = data.split("|")
-            return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
-                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
+            return this.getBaseResponse(data.split("|"));
+        });
     }
 
     getLastSale() {
@@ -37,24 +86,14 @@ module.exports = class POSIntegrado extends POSBase {
 
     getTotals() {
         return this.send("0700||").then((data) => {
-            let chunks = data.split("|")
+            const chunks = data.split("|");
+            const baseResponse = this.getBaseResponse(chunks);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
+                ...baseResponse,
                 txCount: Number.parseInt(chunks[2]),
-                txTotal: Number.parseInt(chunks[3]),
-                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
-    }
-
-    formatNumericString(value, length = 9) {
-        return value.toString().padStart(length, "0").slice(0, length);
-    }
-
-    getBooleanFlag(value) {
-        return (value === true || value === 'true') ? "1" : "0";
+                txTotal: Number.parseInt(chunks[3])
+            };
+        });
     }
 
     salesDetail(printOnPos = false) {
@@ -68,7 +107,7 @@ module.exports = class POSIntegrado extends POSBase {
                 printOnPos = (printOnPos === 'true' || printOnPos === '1')
             }
 
-            let print = printOnPos ? "0":"1"
+            let print = this.getBooleanFlag(!printOnPos);
             let sales = []
 
             let promise = this.send(`0260|${print}|`, !printOnPos, onEverySale.bind(this))
@@ -91,52 +130,51 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     refund(operationId) {
-        if (typeof operationId==="undefined") {
-            throw new Error("Operation ID not provided when calling refund method.")
+        if (typeof operationId === "undefined") {
+            throw new Error("Operation ID not provided when calling refund method.");
         }
 
-        operationId = operationId.toString().slice(0, 6)
+        operationId = operationId.toString().slice(0, 6);
         return this.send(`1200|${operationId}|`).then((data) => {
-            let chunks = data.split("|")
+            const chunks = data.split("|");
+            const baseResponse = this.getBaseResponse(chunks);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
+                ...baseResponse,
                 authorizationCode: chunks[4].trim(),
-                operationId: chunks[5],
-                responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
+                operationId: chunks[5]
+            };
+        });
     }
 
     changeToNormalMode() {
         return this.send("0300", false)
     }
 
-    sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
+    buildSaleCommand(functionCode, amount, ticket, sendStatus, sendVoucher, commerceCode = null) {
         const amountStr = this.formatNumericString(amount, 9);
         const ticketStr = this.formatNumericString(ticket, 6);
         const statusStr = this.getBooleanFlag(sendStatus);
         const voucherStr = this.getBooleanFlag(sendVoucher);
+        
+        let command = `${functionCode}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}`;
+        
+        if (commerceCode !== null) {
+            const commerceCodeStr = this.formatNumericString(commerceCode, 12);
+            command += `|${commerceCodeStr}`;
+        }
+        
+        return command;
+    }
 
-        const command = `${FUNCTION_CODE_SALE_REQUEST}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}`;
-
+    sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
+        const command = this.buildSaleCommand(FUNCTION_CODE_SALE_REQUEST, amount, ticket, sendStatus, sendVoucher);
         return this.send(command, true, callback).then((data) => {
             return this.saleResponse(data);
         });
     }
 
     multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
-        const amountStr = this.formatNumericString(amount, 9);
-        const ticketStr = this.formatNumericString(ticket, 6);
-        const statusStr = this.getBooleanFlag(sendStatus);
-        const voucherStr = this.getBooleanFlag(sendVoucher);
-        const commerceCodeStr = this.formatNumericString(commerceCode || '0', 12);
-
-        const command = `${FUNCTION_CODE_MULTICODE_SALE_REQUEST}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}|${commerceCodeStr}`;
-
+        const command = this.buildSaleCommand(FUNCTION_CODE_MULTICODE_SALE_REQUEST, amount, ticket, sendStatus, sendVoucher, commerceCode);
         return this.send(command, true, callback).then((data) => {
             return this.multicodeSaleResponse(data);
         });
@@ -149,17 +187,10 @@ module.exports = class POSIntegrado extends POSBase {
      */
 
     saleDetailResponse(payload) {
-        let chunks = payload.split("|")
-        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+        const chunks = payload.split("|");
+        const baseSaleResponse = this.getBaseSaleResponse(chunks);
         return {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
+            ...baseSaleResponse,
             amount: chunks[6],
             last4Digits: Number.parseInt(chunks[7]),
             operationNumber: chunks[8],
@@ -171,82 +202,22 @@ module.exports = class POSIntegrado extends POSBase {
             realTime: chunks[14],
             employeeId: chunks[15],
             tip: Number.parseInt(chunks[16]),
-            feeAmount: (chunks[16]),
-            feeNumber: (chunks[17])
-        }
+            feeAmount: chunks[16],
+            feeNumber: chunks[17]
+        };
     }
 
     saleResponse(payload) {
-        let chunks = payload.split("|")
-        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-        let response = {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
-            voucher: null
-        };
-
-        if (chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g)
-        }
-        
-        return response;
+        const chunks = payload.split("|");
+        const response = this.getBaseSaleResponse(chunks);
+        return this.addVoucherToResponse(response, chunks);
     }
 
     multicodeSaleResponse(payload) {
-        let chunks = payload.split("|")
-        let authorizationCode = typeof chunks[5] !== 'undefined'
-            ? chunks[5].trim()
-            : null;
-        let response = {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
-            voucher: null,
-            providerCommerceCode: chunks[21] || null
-        };
-
-        if(chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g)
-        }
-
-        return response;
+        const chunks = payload.split("|");
+        const response = this.getBaseSaleResponse(chunks);
+        response.providerCommerceCode = chunks[21]?.trim() ?? null;
+        return this.addVoucherToResponse(response, chunks);
     }
 
 }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -58,28 +58,6 @@ module.exports = class POSIntegrado extends POSBase {
         return (value === true || value === 'true') ? "1" : "0";
     }
 
-    getCommandParameters(amount, ticket, commerceCode, sendStatus, sendVoucher) {
-        const isMulticodeSale = commerceCode !== null && commerceCode !== '0';
-        const commandCode = isMulticodeSale 
-            ? FUNCTION_CODE_MULTICODE_SALE_REQUEST 
-            : FUNCTION_CODE_SALE_REQUEST;
-        
-        return {
-            commandCode: this.formatNumericString(commandCode, 4),
-            amountStr: this.formatNumericString(amount, 9),
-            ticketStr: this.formatNumericString(ticket, 6),
-            statusStr: this.getBooleanFlag(sendStatus),
-            voucherStr: this.getBooleanFlag(sendVoucher),
-            commerceCodeStr: this.formatNumericString(commerceCode ?? '0', 12)
-        };
-    }
-
-
-
-    buildMulticodeSaleCommand(params) {
-        return `${params.commandCode}|${params.amountStr}|${params.ticketStr}||${params.voucherStr}|${params.statusStr}|${params.commerceCodeStr}`;
-    }
-
     salesDetail(printOnPos = false) {
         return new Promise((resolve, reject) => {
 
@@ -196,44 +174,75 @@ module.exports = class POSIntegrado extends POSBase {
 
     saleResponse(payload) {
         let chunks = payload.split("|")
-            let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-            let response = {
-                functionCode: parseInt(chunks[0]),
-                responseCode: parseInt(chunks[1]),
-                commerceCode: parseInt(chunks[2]),
-                terminalId: chunks[3],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: parseInt(chunks[1])===0,
-                ticket: chunks[4],
-                authorizationCode: authorizationCode,
-                amount: parseInt(chunks[6]),
-                sharesNumber: chunks[7],
-                sharesAmount: chunks[8],
-                last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
-                operationNumber: chunks[10],
-                cardType: chunks[11],
-                accountingDate: chunks[12],
-                accountNumber: chunks[13],
-                cardBrand: chunks[14],
-                realDate: chunks[15],
-                realTime: chunks[16],
-                employeeId: chunks[17],
-                tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
-                commerceCodeSent: null,
-                voucher: null
-            };
+        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+        let response = {
+            functionCode: parseInt(chunks[0]),
+            responseCode: parseInt(chunks[1]),
+            commerceCode: parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+            successful: parseInt(chunks[1])===0,
+            ticket: chunks[4],
+            authorizationCode: authorizationCode,
+            amount: parseInt(chunks[6]),
+            sharesNumber: chunks[7],
+            sharesAmount: chunks[8],
+            last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
+            operationNumber: chunks[10],
+            cardType: chunks[11],
+            accountingDate: chunks[12],
+            accountNumber: chunks[13],
+            cardBrand: chunks[14],
+            realDate: chunks[15],
+            realTime: chunks[16],
+            employeeId: chunks[17],
+            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
+            commerceCodeSent: null,
+            voucher: null
+        };
 
-            const functionCodeStr = response.functionCode.toString(); 
-
-            if (functionCodeStr !== FUNCTION_CODE_MULTICODE_SALE && chunks[19] && chunks[19].length > 1) {
-                response.voucher = chunks[19]?.match(/.{1,40}/g)
-            }
-            
-            if (functionCodeStr === FUNCTION_CODE_MULTICODE_SALE) {
-                response.providerCommerceCode = chunks[21] || null;
-                response.commerceCodeSent = chunks[21] || null;
-            }
+        if (chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g)
+        }
         
+        return response;
+    }
+
+    multicodeSaleResponse(payload) {
+        let chunks = payload.split("|")
+        let authorizationCode = typeof chunks[5] !== 'undefined'
+            ? chunks[5].trim()
+            : null;
+        let response = {
+            functionCode: Number.parseInt(chunks[0]),
+            responseCode: Number.parseInt(chunks[1]),
+            commerceCode: Number.parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
+            successful: Number.parseInt(chunks[1])===0,
+            ticket: chunks[4],
+            authorizationCode: authorizationCode,
+            amount: Number.parseInt(chunks[6]),
+            sharesNumber: chunks[7],
+            sharesAmount: chunks[8],
+            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
+            operationNumber: chunks[10],
+            cardType: chunks[11],
+            accountingDate: chunks[12],
+            accountNumber: chunks[13],
+            cardBrand: chunks[14],
+            realDate: chunks[15],
+            realTime: chunks[16],
+            employeeId: chunks[17],
+            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
+            voucher: null,
+            commerceProviderCode: chunks[21] || null
+        };
+
+        if(chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g)
+        }
+
         return response;
     }
 

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,5 +1,8 @@
 const POSBase = require('./PosBase')
 const FUNCTION_CODE_MULTICODE_SALE = '0271';
+const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
+const FUNCTION_CODE_MULTICODE_CASHBACK_SALE_REQUEST = '0280';
+const FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE = '281';
 
 module.exports = class POSIntegrado extends POSBase {
 
@@ -46,6 +49,36 @@ module.exports = class POSIntegrado extends POSBase {
                 successful: parseInt(chunks[1])===0
             }
         })
+    }
+
+    formatNumericString(value, length = 9) {
+        return value.toString().padStart(length, "0").slice(0, length);
+    }
+
+    getBooleanFlag(value) {
+        return (value === true || value === 'true') ? "1" : "0";
+    }
+
+    getCommandParameters(amount, ticket, commerceCode, cashbackAmount, sendStatus, sendVoucher) {
+        const numericCashback = Number.parseInt(cashbackAmount) || 0;
+        const hasCashback = numericCashback > 0;
+
+        return {
+            commandCode: hasCashback ? FUNCTION_CODE_MULTICODE_CASHBACK_SALE_REQUEST : FUNCTION_CODE_MULTICODE_SALE_REQUEST,
+            amountStr: this.formatNumericString(amount, 9),
+            ticketStr: this.formatNumericString(ticket, 6),
+            cashbackStr: hasCashback ? this.formatNumericString(numericCashback, 9) : "",
+            statusStr: this.getBooleanFlag(sendStatus),
+            voucherStr: hasCashback ? "0" : this.getBooleanFlag(sendVoucher),
+            commerceCodeStr: this.formatNumericString(commerceCode ?? '0', 12),
+            numericCashback
+        };
+    }
+
+
+
+    buildMulticodeSaleCommand(params) {
+        return `${params.commandCode}|${params.amountStr}|${params.ticketStr}|${params.cashbackStr}|${params.voucherStr}|${params.statusStr}|${params.commerceCodeStr}`;
     }
 
     salesDetail(printOnPos = false) {
@@ -117,28 +150,16 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, printOnPOS = false, callback = null) {
-        const numericCashback = Number.parseInt(cashbackAmount) || 0;
-        const commandCode = numericCashback > 0 ? "0280" : "0270";
-
-        const amountStr = amount.toString().padStart(9, "0").slice(0, 9);
-        const ticketStr = ticket.toString().padStart(6, "0").slice(0, 6);
-        const statusStr = sendStatus ? "1" : "0";
-        const voucherPrintCommand = printOnPOS ? "1" : "0";
-        
-        const actualCommerceCode = commerceCode === null ? '0' : commerceCode.toString().padStart(12, '0');
-        const actualCashbackAmount = numericCashback;
-        
-        const cashbackStr = (numericCashback > 0) ? numericCashback.toString().padStart(9, "0").slice(0, 9) : "";
-
-        const command = `${commandCode}|${amountStr}|${ticketStr}|${cashbackStr}|${voucherPrintCommand}|${statusStr}|${actualCommerceCode}`;
+    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
+        const params = this.getCommandParameters(amount, ticket, commerceCode, cashbackAmount, sendStatus, sendVoucher);
+        const command = this.buildMulticodeSaleCommand(params);
 
         return this.send(command, true, callback).then((data) => {
             const parsedResponse = this.saleResponse(data);
             
-            if (parsedResponse.functionCode.toString() === '281') {
-                parsedResponse.cashbackSent = actualCashbackAmount;
-                parsedResponse.commerceCodeSent = actualCommerceCode;
+            if (parsedResponse.functionCode.toString() === FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE) {
+                parsedResponse.cashbackSent = params.numericCashback;
+                parsedResponse.commerceCodeSent = params.commerceCodeStr;
             }
 
             return parsedResponse;
@@ -203,16 +224,21 @@ module.exports = class POSIntegrado extends POSBase {
                 realDate: chunks[15],
                 realTime: chunks[16],
                 employeeId: chunks[17],
-                tip: chunks[18] === '' ? null : Number.parseInt(chunks[18])
+                tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
+                commerceCodeSent: null,
+                providerCommerceCode: null,
+                voucher: null
             };
 
             const functionCodeStr = response.functionCode.toString(); 
 
-            if (functionCodeStr !== '281' && chunks[19] && chunks[19].length > 1) {
+            if (functionCodeStr !== FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE && chunks[19] 
+                && chunks[19].length > 1) {
                 response.voucher = chunks[19]?.match(/.{1,40}/g)
             }
             
-            if (functionCodeStr === '271' || functionCodeStr === '281') {
+            if (functionCodeStr === FUNCTION_CODE_MULTICODE_SALE || 
+                functionCodeStr === FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE) {
                 response.cashback = Number.parseInt(chunks[20]) || 0;
                 response.providerCommerceCode = chunks[21]; 
             }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,8 +1,7 @@
 const POSBase = require('./PosBase')
 const FUNCTION_CODE_MULTICODE_SALE = '0271';
 const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
-const FUNCTION_CODE_MULTICODE_CASHBACK_SALE_REQUEST = '0280';
-const FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE = '281';
+const FUNCTION_CODE_SALE_REQUEST = '0200';
 
 module.exports = class POSIntegrado extends POSBase {
 
@@ -59,26 +58,26 @@ module.exports = class POSIntegrado extends POSBase {
         return (value === true || value === 'true') ? "1" : "0";
     }
 
-    getCommandParameters(amount, ticket, commerceCode, cashbackAmount, sendStatus, sendVoucher) {
-        const numericCashback = Number.parseInt(cashbackAmount) || 0;
-        const hasCashback = numericCashback > 0;
-
+    getCommandParameters(amount, ticket, commerceCode, sendStatus, sendVoucher) {
+        const isMulticodeSale = commerceCode !== null && commerceCode !== '0';
+        const commandCode = isMulticodeSale 
+            ? FUNCTION_CODE_MULTICODE_SALE_REQUEST 
+            : FUNCTION_CODE_SALE_REQUEST;
+        
         return {
-            commandCode: hasCashback ? FUNCTION_CODE_MULTICODE_CASHBACK_SALE_REQUEST : FUNCTION_CODE_MULTICODE_SALE_REQUEST,
+            commandCode: this.formatNumericString(commandCode, 4),
             amountStr: this.formatNumericString(amount, 9),
             ticketStr: this.formatNumericString(ticket, 6),
-            cashbackStr: hasCashback ? this.formatNumericString(numericCashback, 9) : "",
             statusStr: this.getBooleanFlag(sendStatus),
-            voucherStr: hasCashback ? "0" : this.getBooleanFlag(sendVoucher),
-            commerceCodeStr: this.formatNumericString(commerceCode ?? '0', 12),
-            numericCashback
+            voucherStr: this.getBooleanFlag(sendVoucher),
+            commerceCodeStr: this.formatNumericString(commerceCode ?? '0', 12)
         };
     }
 
 
 
     buildMulticodeSaleCommand(params) {
-        return `${params.commandCode}|${params.amountStr}|${params.ticketStr}|${params.cashbackStr}|${params.voucherStr}|${params.statusStr}|${params.commerceCodeStr}`;
+        return `${params.commandCode}|${params.amountStr}|${params.ticketStr}||${params.voucherStr}|${params.statusStr}|${params.commerceCodeStr}`;
     }
 
     salesDetail(printOnPos = false) {
@@ -150,18 +149,13 @@ module.exports = class POSIntegrado extends POSBase {
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, cashbackAmount = 0, sendStatus = false, sendVoucher = false, callback = null) {
-        const params = this.getCommandParameters(amount, ticket, commerceCode, cashbackAmount, sendStatus, sendVoucher);
+    multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
+        const params = this.getCommandParameters(amount, ticket, commerceCode, sendStatus, sendVoucher);
         const command = this.buildMulticodeSaleCommand(params);
 
         return this.send(command, true, callback).then((data) => {
             const parsedResponse = this.saleResponse(data);
-            
-            if (parsedResponse.functionCode.toString() === FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE) {
-                parsedResponse.cashbackSent = params.numericCashback;
-                parsedResponse.commerceCodeSent = params.commerceCodeStr;
-            }
-
+            parsedResponse.commerceCodeSent = params.commerceCodeStr;
             return parsedResponse;
         });
     }
@@ -226,21 +220,18 @@ module.exports = class POSIntegrado extends POSBase {
                 employeeId: chunks[17],
                 tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
                 commerceCodeSent: null,
-                providerCommerceCode: null,
                 voucher: null
             };
 
             const functionCodeStr = response.functionCode.toString(); 
 
-            if (functionCodeStr !== FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE && chunks[19] 
-                && chunks[19].length > 1) {
+            if (functionCodeStr !== FUNCTION_CODE_MULTICODE_SALE && chunks[19] && chunks[19].length > 1) {
                 response.voucher = chunks[19]?.match(/.{1,40}/g)
             }
             
-            if (functionCodeStr === FUNCTION_CODE_MULTICODE_SALE || 
-                functionCodeStr === FUNCTION_CODE_MULTICODE_CASHBACK_SALE_RESPONSE) {
-                response.cashback = Number.parseInt(chunks[20]) || 0;
-                response.providerCommerceCode = chunks[21]; 
+            if (functionCodeStr === FUNCTION_CODE_MULTICODE_SALE) {
+                response.providerCommerceCode = chunks[21] || null;
+                response.commerceCodeSent = chunks[21] || null;
             }
         
         return response;

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -106,12 +106,13 @@ module.exports = class POSIntegrado extends POSBase {
         return this.send("0300", false)
     }
 
-    sale(amount, ticket, sendStatus = false, callback = null) {
+    sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
         amount = amount.toString().padStart(9, "0").slice(0, 9)
         ticket = ticket.toString().padStart(6, "0").slice(0, 6)
         let status = sendStatus ? "1":"0"
+        let voucher = sendVoucher ? "1" : "0"
 
-        return this.send(`0200|${amount}|${ticket}|||${status}`, true, callback).then((data) => {
+        return this.send(`0200|${amount}|${ticket}||${voucher}|${status}`, true, callback).then((data) => {
             return this.saleResponse(data)
         })
     }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -117,24 +117,29 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
-        amount = amount.toString().padStart(9, "0").slice(0, 9);
-        ticket = ticket.toString().padStart(6, "0").slice(0, 6);
-        let status = sendStatus ? "1" : "0";
-        let voucher = sendVoucher ? "1" : "0";
+        const amountStr = this.formatNumericString(amount, 9);
+        const ticketStr = this.formatNumericString(ticket, 6);
+        const statusStr = this.getBooleanFlag(sendStatus);
+        const voucherStr = this.getBooleanFlag(sendVoucher);
 
-        return this.send(`0200|${amount}|${ticket}||${voucher}|${status}`, true, callback).then((data) => {
+        const command = `${FUNCTION_CODE_SALE_REQUEST}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}`;
+
+        return this.send(command, true, callback).then((data) => {
             return this.saleResponse(data);
         });
     }
 
     multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
-        const params = this.getCommandParameters(amount, ticket, commerceCode, sendStatus, sendVoucher);
-        const command = this.buildMulticodeSaleCommand(params);
+        const amountStr = this.formatNumericString(amount, 9);
+        const ticketStr = this.formatNumericString(ticket, 6);
+        const statusStr = this.getBooleanFlag(sendStatus);
+        const voucherStr = this.getBooleanFlag(sendVoucher);
+        const commerceCodeStr = commerceCode ? commerceCode.toString() : '';
+
+        const command = `${FUNCTION_CODE_MULTICODE_SALE_REQUEST}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}|${commerceCodeStr}`;
 
         return this.send(command, true, callback).then((data) => {
-            const parsedResponse = this.saleResponse(data);
-            parsedResponse.commerceCodeSent = params.commerceCodeStr;
-            return parsedResponse;
+            return this.multicodeSaleResponse(data);
         });
     }
 

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -10,55 +10,8 @@ module.exports = class POSIntegrado extends POSBase {
      |--------------------------------------------------------------------------
      */
 
-    formatNumericString(value, length = 9) {
-        return value.toString().padStart(length, "0").slice(0, length);
-    }
-
     getBooleanFlag(value) {
-        return (value === true || value === 'true') ? "1" : "0";
-    }
-
-    getBaseResponse(chunks) {
-        return {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage(Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1]) === 0
-        };
-    }
-
-    getBaseSaleResponse(chunks) {
-        const baseResponse = this.getBaseResponse(chunks);
-        const authorizationCode = chunks[5]?.trim() ?? null;
-
-        return {
-            ...baseResponse,
-            ticket: chunks[4],
-            authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] === '' ? null : Number.parseInt(chunks[9]),
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] === '' ? null : Number.parseInt(chunks[18]),
-            voucher: null
-        };
-    }
-
-    addVoucherToResponse(response, chunks) {
-        if (chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g);
-        }
-        return response;
+        return value ? "1" : "0";
     }
 
     /*
@@ -130,20 +83,24 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     refund(operationId) {
-        if (typeof operationId === "undefined") {
-            throw new TypeError("Operation ID not provided when calling refund method.");
+        if (typeof operationId==="undefined") {
+            throw new Error("Operation ID not provided when calling refund method.")
         }
 
-        operationId = operationId.toString().slice(0, 6);
+        operationId = operationId.toString().slice(0, 6)
         return this.send(`1200|${operationId}|`).then((data) => {
-            const chunks = data.split("|");
-            const baseResponse = this.getBaseResponse(chunks);
+            let chunks = data.split("|")
             return {
-                ...baseResponse,
+                functionCode: parseInt(chunks[0]),
+                responseCode: parseInt(chunks[1]),
+                commerceCode: parseInt(chunks[2]),
+                terminalId: chunks[3],
                 authorizationCode: chunks[4].trim(),
-                operationId: chunks[5]
-            };
-        });
+                operationId: chunks[5],
+                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+                successful: parseInt(chunks[1])===0
+            }
+        })
     }
 
     changeToNormalMode() {
@@ -151,16 +108,19 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     buildSaleCommand(functionCode, amount, ticket, sendStatus, sendVoucher, commerceCode = null) {
-        const amountStr = this.formatNumericString(amount, 9);
-        const ticketStr = this.formatNumericString(ticket, 6);
         const statusStr = this.getBooleanFlag(sendStatus);
-        const voucherStr = this.getBooleanFlag(sendVoucher);
+
+        if (functionCode === FUNCTION_CODE_MULTICODE_SALE_REQUEST) {
+            const code = commerceCode && commerceCode !== '0' ? commerceCode : '';
+            const voucherStr = this.getBooleanFlag(sendVoucher);
+            return `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}|${code}|`;
+        }
         
-        let command = `${functionCode}|${amountStr}|${ticketStr}||${voucherStr}|${statusStr}`;
+        const voucherStr = this.getBooleanFlag(sendVoucher);
+        let command = `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}`;
         
         if (commerceCode !== null) {
-            const commerceCodeStr = this.formatNumericString(commerceCode, 12);
-            command += `|${commerceCodeStr}`;
+            command += `|${commerceCode}`;
         }
         
         return command;
@@ -186,13 +146,20 @@ module.exports = class POSIntegrado extends POSBase {
      |--------------------------------------------------------------------------
      */
 
-    saleDetailResponse(payload) {
-        const chunks = payload.split("|");
-        const baseSaleResponse = this.getBaseSaleResponse(chunks);
+     saleDetailResponse(payload) {
+        let chunks = payload.split("|")
+        let authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
         return {
-            ...baseSaleResponse,
+            functionCode: parseInt(chunks[0]),
+            responseCode: parseInt(chunks[1]),
+            commerceCode: parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+            successful: parseInt(chunks[1])===0,
+            ticket: chunks[4],
+            authorizationCode: authorizationCode,
             amount: chunks[6],
-            last4Digits: Number.parseInt(chunks[7]),
+            last4Digits: parseInt(chunks[7]),
             operationNumber: chunks[8],
             cardType: chunks[9],
             accountingDate: chunks[10],
@@ -201,23 +168,82 @@ module.exports = class POSIntegrado extends POSBase {
             realDate: chunks[13],
             realTime: chunks[14],
             employeeId: chunks[15],
-            tip: Number.parseInt(chunks[16]),
-            feeAmount: chunks[16],
-            feeNumber: chunks[17]
-        };
+            tip: parseInt(chunks[16]),
+            feeAmount: (chunks[16]),
+            feeNumber: (chunks[17])
+        }
     }
 
     saleResponse(payload) {
         const chunks = payload.split("|");
-        const response = this.getBaseSaleResponse(chunks);
-        return this.addVoucherToResponse(response, chunks);
+        const authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+        const response = {
+            functionCode: parseInt(chunks[0]),
+            responseCode: parseInt(chunks[1]),
+            commerceCode: parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+            successful: parseInt(chunks[1])===0,
+            ticket: chunks[4],
+            authorizationCode: authorizationCode,
+            amount: parseInt(chunks[6]),
+            sharesNumber: chunks[7],
+            sharesAmount: chunks[8],
+            last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
+            operationNumber: chunks[10],
+            cardType: chunks[11],
+            accountingDate: chunks[12],
+            accountNumber: chunks[13],
+            cardBrand: chunks[14],
+            realDate: chunks[15],
+            realTime: chunks[16],
+            employeeId: chunks[17],
+            tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
+            voucher: null
+        }
+        
+        if (chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g);
+        }
+
+        return response;
     }
 
     multicodeSaleResponse(payload) {
         const chunks = payload.split("|");
-        const response = this.getBaseSaleResponse(chunks);
-        response.providerCommerceCode = chunks[21]?.trim() ?? null;
-        return this.addVoucherToResponse(response, chunks);
+        const authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
+        const response = {
+            functionCode: parseInt(chunks[0]),
+            responseCode: parseInt(chunks[1]),
+            commerceCode: parseInt(chunks[2]),
+            terminalId: chunks[3],
+            responseMessage: this.getResponseMessage(parseInt(chunks[1])),
+            successful: parseInt(chunks[1])===0,
+            ticket: chunks[4],
+            authorizationCode: authorizationCode,
+            amount: parseInt(chunks[6]),
+            sharesNumber: chunks[7],
+            sharesAmount: chunks[8],
+            last4Digits: chunks[9] !== '' ? parseInt(chunks[9]) : null,
+            operationNumber: chunks[10],
+            cardType: chunks[11],
+            accountingDate: chunks[12],
+            accountNumber: chunks[13],
+            cardBrand: chunks[14],
+            realDate: chunks[15],
+            realTime: chunks[16],
+            employeeId: chunks[17],
+            tip: chunks[18] !== '' ? parseInt(chunks[18]) : null,
+            voucher: null,
+            change: chunks[20],
+            commerceCode: chunks[21]
+        }
+
+        if (chunks[19] && chunks[19].length > 1) {
+            response.voucher = chunks[19]?.match(/.{1,40}/g);
+        }
+
+        return response
     }
 
 }


### PR DESCRIPTION
this PR adds the functionality to choice if print the voucher inside the response or let the POS print it on paper.

Consider that in the case of multicode sale, if there is cashback, the voucher is always printed by protocol so that question is skipped

## Tests
**Normal sale - voucher on response**
<img width="519" height="779" alt="Captura de pantalla 2025-10-10 a las 10 46 05" src="https://github.com/user-attachments/assets/f23f4a81-5f84-4dff-963c-3c55c234cc26" />

**Normal sale - voucher on POS**
<img width="430" height="491" alt="Captura de pantalla 2025-10-10 a las 10 50 44" src="https://github.com/user-attachments/assets/8de1b409-88fb-435f-9e13-202e9c5f7d27" />

**Multicode sale - voucher on response**
<img width="596" height="847" alt="Captura de pantalla 2025-10-10 a las 15 19 42" src="https://github.com/user-attachments/assets/045ad372-6f04-4aaa-b4de-e03b784b2e73" />

**Multicode sale - voucher on POS **
<img width="483" height="531" alt="Captura de pantalla 2025-10-10 a las 15 20 34" src="https://github.com/user-attachments/assets/669e1276-0930-48d8-8881-f8540a8fc12c" />

