### PR TITLE
feat: improve details command

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -267,62 +267,6 @@ const saleOperation = async function() {
 }
 
 const multicodeSaleOperation = async function() {
-    const saleAmount = await input({
-        message: 'Ingrese el monto de la venta:',
-        default: '1000'
-    });
-
-    const ticket = await input({
-        message: 'Ingrese el ticket de la venta:',
-        default: 'MC1234'
-    });
-
-    const commerceCode = await input({
-        message: 'Ingrese el código de comercio (dejar en 0 si no aplica):',
-        default: '0'
-    });
-
-    const intermediateMessages = await select({
-        message: 'Recibir mensajes intermedios?',
-        choices: [
-            { name: 'Si', value: true },
-            { name: 'No', value: false }
-        ]
-    });
-    
-    const printVoucher = await select({
-        message: '¿Desea el voucher en la respuesta JSON?',
-        choices: [
-            {
-                name: 'Si',
-                value: true,
-                description: 'Se imprimirá el voucher en la respuesta' 
-            },
-            {
-                name: 'No',
-                value: false,
-                description: 'El POS imprimirá el voucher'
-            }
-        ]
-    });
-
-    await pos.multicodeSale(
-        saleAmount, 
-        ticket, 
-        commerceCode, 
-        intermediateMessages, 
-        printVoucher, 
-        (intermediateResponse) => console.log(intermediateResponse)
-    )
-    .then(response => {
-        console.log('Respuesta de la venta multicódigo:', response);
-    })
-    .catch(error => {
-        console.log('Error en la venta multicódigo:', error)
-    });
-}
-
-const multicodeSaleOperation = async function() {
     const amount = await input({
         message: 'Ingrese el monto de la venta:',
         default: '1000'

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -4,6 +4,8 @@ const EventEmitter = require('events');
 const { InterByteTimeoutParser } = require("@serialport/parser-inter-byte-timeout")
 const responseMessages = require("./responseCodes");
 const ACK = 0x06
+const FUNCTION_CODE_INTERMEDIATE_MESSAGE = "0900";
+const FUNCTION_CODE_SALES_DETAIL_RESPONSE = "0261";
 
 module.exports = class POSBase extends EventEmitter {
 
@@ -285,14 +287,14 @@ module.exports = class POSBase extends EventEmitter {
                 }
                 let functionCode = data.toString().slice(1, 5)
 
-                if (functionCode === "0900") { // Sale status messages
+                if (functionCode === FUNCTION_CODE_INTERMEDIATE_MESSAGE) { 
                     if (typeof callback === "function"){
                         callback(this.intermediateResponse(response), data)
                     }
                     return
                 }
 
-                if (functionCode === "0261") {
+                if (functionCode === FUNCTION_CODE_SALES_DETAIL_RESPONSE) {
                     clearTimeout(responseTimeout)
                     responseTimeout = setTimeout(() => {
                         this.waiting = false

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -300,7 +300,7 @@ module.exports = class POSBase extends EventEmitter {
                 if (functionCode === "0261") {
                     if (typeof callback === "function") {
                         const isFinished = callback(response, data);
-                        if (isFinished === true) {
+                        if (isFinished) {
                             clearTimeout(responseTimeout);
                             this.waiting = false;
                             resolve(response, data);

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -275,46 +275,44 @@ module.exports = class POSBase extends EventEmitter {
                 this.waiting = false
                 reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds`))
             }, this.posTimeout)
-
+            
             // Wait for the response and fullfill the Promise
             this.responseCallback = (data) => {
                 clearTimeout(responseTimeout)
                 responseTimeout = setTimeout(() => {
-                    this.waiting = false;
+                    this.waiting = false
                     reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds after last message`))
-                }, this.posTimeout);
+                }, this.posTimeout)
 
                 let response = data
                 if (this.responseAsString) {
-                    const isFinished = callback(response, data);
-                    if (isFinished === true) {
-                        clearTimeout(responseTimeout);
-                        this.waiting = false;
-                        resolve(response,data)
-                    }
-                    
-                    return 
+                    response = data.toString().slice(1, -2)
                 }
                 let functionCode = data.toString().slice(1, 5)
-                
+
                 if (functionCode === "0900") { // Sale status messages
                     if (typeof callback === "function"){
                         callback(this.intermediateResponse(response), data)
                     }
                     return
                 }
+
                 if (functionCode === "0261") {
-                    if (typeof callback === "function"){
-                        callback(response, data)
+                    if (typeof callback === "function") {
+                        const isFinished = callback(response, data);
+                        if (isFinished === true) {
+                            clearTimeout(responseTimeout);
+                            this.waiting = false;
+                            resolve(response, data);
+                        }
+                        return; 
                     }
-                    return
                 }
 
+                clearTimeout(responseTimeout)
                 this.waiting = false
-
                 resolve(response, data)
             }
-
         })
     }
 

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -280,6 +280,7 @@ module.exports = class POSBase extends EventEmitter {
             
             // Wait for the response and fullfill the Promise
             this.responseCallback = (data) => {
+                clearTimeout(responseTimeout)
                 let response = data
 
                 if (this.responseAsString) {
@@ -295,7 +296,6 @@ module.exports = class POSBase extends EventEmitter {
                 }
 
                 if (functionCode === FUNCTION_CODE_SALES_DETAIL_RESPONSE) {
-                    clearTimeout(responseTimeout)
                     responseTimeout = setTimeout(() => {
                         this.waiting = false
                         reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds after last message`))

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -278,13 +278,8 @@ module.exports = class POSBase extends EventEmitter {
             
             // Wait for the response and fullfill the Promise
             this.responseCallback = (data) => {
-                clearTimeout(responseTimeout)
-                responseTimeout = setTimeout(() => {
-                    this.waiting = false
-                    reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds after last message`))
-                }, this.posTimeout)
-
                 let response = data
+
                 if (this.responseAsString) {
                     response = data.toString().slice(1, -2)
                 }
@@ -298,6 +293,11 @@ module.exports = class POSBase extends EventEmitter {
                 }
 
                 if (functionCode === "0261") {
+                    clearTimeout(responseTimeout)
+                    responseTimeout = setTimeout(() => {
+                        this.waiting = false
+                        reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds after last message`))
+                    }, this.posTimeout)
                     if (typeof callback === "function") {
                         const isFinished = callback(response, data);
                         if (isFinished) {

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -279,9 +279,21 @@ module.exports = class POSBase extends EventEmitter {
             // Wait for the response and fullfill the Promise
             this.responseCallback = (data) => {
                 clearTimeout(responseTimeout)
+                responseTimeout = setTimeout(() => {
+                    this.waiting = false;
+                    reject(new Error(`Response of POS has not been received in ${this.posTimeout / 1000} seconds after last message`))
+                }, this.posTimeout);
+
                 let response = data
                 if (this.responseAsString) {
-                    response = data.toString().slice(1, -2)
+                    const isFinished = callback(response, data);
+                    if (isFinished === true) {
+                        clearTimeout(responseTimeout);
+                        this.waiting = false;
+                        resolve(response,data)
+                    }
+                    
+                    return 
                 }
                 let functionCode = data.toString().slice(1, 5)
                 

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -309,9 +309,9 @@ module.exports = class POSBase extends EventEmitter {
                         }
                         return; 
                     }
+                    clearTimeout(responseTimeout)
                 }
 
-                clearTimeout(responseTimeout)
                 this.waiting = false
                 resolve(response, data)
             }

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -60,43 +60,38 @@ module.exports = class POSIntegrado extends POSBase {
                 printOnPos = (printOnPos === 'true' || printOnPos === '1')
             }
 
+            let print = printOnPos ? "0":"1"
+
             if (printOnPos) {
-                this.send(`0260|0|`, false)
-                    .then(() => resolve(true))
-                    .catch(reject);
-                return;
+                    this.send(`0260|${print}|`, false)
+                        .then(() => resolve(true))
+                        .catch(reject);
+                    return;
             }
 
             let sales = [];
             let consecutiveEmptyAuthCodes = 0;
-            const command = `0260|1|`;
+            const command = `0260|${print}|`;
 
             const processDetailResponse = (responsePayload, rawData) => {
-                const functionCode = rawData.toString.slice(1, 5);
-
-                if (functionCode !== '0261') {
-                    this.debug("Received unexpected function code during salesDetail:", functionCode, responsePayload);
-                    return false;
-                }
-
                 let detail = this.saleDetailResponse(responsePayload);
 
                 if (detail.authorizationCode === "" || detail.authorizationCode === null) {
                     consecutiveEmptyAuthCodes++;
                     this.debug(`SalesDetail: Received empty auth code. Count: ${consecutiveEmptyAuthCodes}`);
                 } else {
-                    consecutiveEmptyAuthCodes = 0; 
-                    sales.push(detail); 
-                    this.debug(`SalesDetail: Received sale with AuthCode ${detail.authorizationCode}. Count reset.`);
+                    consecutiveEmptyAuthCodes = 0;
+                    sales.push(detail);
+                    this.debug(`SalesDetail: Received sale with AuthCode ${detail.authorizationCode}.`);
                 }
 
                 if (consecutiveEmptyAuthCodes >= 2) {
-                    this.debug("SalesDetail: End condition met (2 consecutive empty auth codes). Resolving.");
+                    this.debug("SalesDetail: End condition met (2 consecutive empty). Returning TRUE.");
                     return true;
                 }
 
                 return false;
-            }
+            };
 
             this.send(command, true, processDetailResponse)
                 .then(() => {
@@ -106,9 +101,7 @@ module.exports = class POSIntegrado extends POSBase {
                     this.debug("SalesDetail: Error during send/receive.", error);
                     reject(error);
                 });
-
-        })
-
+        });
     }
 
     refund(operationId) {

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,6 +1,7 @@
 const POSBase = require('./PosBase');
 const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
 const FUNCTION_CODE_SALE_REQUEST = '0200';
+const CONSECUTIVE_EMPTY_AUTHCODE_LIMIT = 2;
 
 module.exports = class POSIntegrado extends POSBase {
 
@@ -83,7 +84,7 @@ module.exports = class POSIntegrado extends POSBase {
                     sales.push(detail);
                 }
 
-                if (consecutiveEmptyAuthCodes >= 2) {;
+                if (consecutiveEmptyAuthCodes >= CONSECUTIVE_EMPTY_AUTHCODE_LIMIT) {;
                     return true;
                 }
 

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,4 +1,4 @@
-const POSBase = require('./PosBase')
+const POSBase = require('./PosBase');
 const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
 const FUNCTION_CODE_SALE_REQUEST = '0200';
 
@@ -78,15 +78,12 @@ module.exports = class POSIntegrado extends POSBase {
 
                 if (detail.authorizationCode === "" || detail.authorizationCode === null) {
                     consecutiveEmptyAuthCodes++;
-                    this.debug(`SalesDetail: Received empty auth code. Count: ${consecutiveEmptyAuthCodes}`);
                 } else {
                     consecutiveEmptyAuthCodes = 0;
                     sales.push(detail);
-                    this.debug(`SalesDetail: Received sale with AuthCode ${detail.authorizationCode}.`);
                 }
 
-                if (consecutiveEmptyAuthCodes >= 2) {
-                    this.debug("SalesDetail: End condition met (2 consecutive empty). Returning TRUE.");
+                if (consecutiveEmptyAuthCodes >= 2) {;
                     return true;
                 }
 
@@ -98,7 +95,6 @@ module.exports = class POSIntegrado extends POSBase {
                     resolve(sales);
                 })
                 .catch(error => {
-                    this.debug("SalesDetail: Error during send/receive.", error);
                     reject(error);
                 });
         });

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -60,23 +60,52 @@ module.exports = class POSIntegrado extends POSBase {
                 printOnPos = (printOnPos === 'true' || printOnPos === '1')
             }
 
-            let print = this.getBooleanFlag(!printOnPos);
-            let sales = []
-
-            let promise = this.send(`0260|${print}|`, !printOnPos, onEverySale.bind(this))
             if (printOnPos) {
-                resolve(promise)
+                this.send(`0260|0|`, false)
+                    .then(() => resolve(true))
+                    .catch(reject);
+                return;
             }
 
-            function onEverySale(sale) {
+            let sales = [];
+            let consecutiveEmptyAuthCodes = 0;
+            const command = `0260|1|`;
 
-                let detail = this.saleDetailResponse(sale.toString().slice(1, -2))
-                if (detail.authorizationCode=== "" || detail.authorizationCode === null) {
-                    resolve(sales)
-                    return
+            const processDetailResponse = (responsePayload, rawData) => {
+                const functionCode = rawData.toString.slice(1, 5);
+
+                if (functionCode !== '0261') {
+                    this.debug("Received unexpected function code during salesDetail:", functionCode, responsePayload);
+                    return false;
                 }
-                sales.push(detail)
+
+                let detail = this.saleDetailResponse(responsePayload);
+
+                if (detail.authorizationCode === "" || detail.authorizationCode === null) {
+                    consecutiveEmptyAuthCodes++;
+                    this.debug(`SalesDetail: Received empty auth code. Count: ${consecutiveEmptyAuthCodes}`);
+                } else {
+                    consecutiveEmptyAuthCodes = 0; 
+                    sales.push(detail); 
+                    this.debug(`SalesDetail: Received sale with AuthCode ${detail.authorizationCode}. Count reset.`);
+                }
+
+                if (consecutiveEmptyAuthCodes >= 2) {
+                    this.debug("SalesDetail: End condition met (2 consecutive empty auth codes). Resolving.");
+                    return true;
+                }
+
+                return false;
             }
+
+            this.send(command, true, processDetailResponse)
+                .then(() => {
+                    resolve(sales);
+                })
+                .catch(error => {
+                    this.debug("SalesDetail: Error during send/receive.", error);
+                    reject(error);
+                });
 
         })
 


### PR DESCRIPTION
This PR updates the way PosBase.js handles responses when a saleDetails operation is sent, now considering that after all the sales there are 2 last messages with no authorization code indicating that the list of sales was complete.

PD: I don't know how but the multisaleCommand ended being duplicated, so I deleted the wrong copy in order to keep the version clean

## Before
SDK didn't recognize the 2 last messages, making a buggy handling of them.
<img width="658" height="443" alt="Imagen 1" src="https://github.com/user-attachments/assets/f0708949-bed4-4612-97d3-ac417696322b" />

## After
SDK recognizes the 2 last messages, ending the listening and showing the list of sales.
<img width="650" height="369" alt="Imagen 2" src="https://github.com/user-attachments/assets/e0c70259-b5a2-456e-a00b-9f180a96b0f5" />

