### PR TITLE
feat: normalize responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,252 +3,350 @@
 SDK Oficial de Transbank para comunicarse con POS Verifone vx520, vx520c, Ingenico 3500 y POS Autoservicio
 
 ## Requisitos
+
 - Node.js 20+
 - Python 3
 - NPM
 
 ## Instalación
-Para instalar este SDK en tu proyecto, solo debes incluirlo usando npm/yarn. 
+
+Para instalar este SDK en tu proyecto, solo debes incluirlo usando npm/yarn.
+
 ```bash
 npm install transbank-pos-sdk
 ```
 
 ### ¿Cómo se usa?
-Como se explica más abajo, la documentación oficial está en [Transbank developers](https://www.transbankdevelopers.cl/producto/posintegrado), pero como una breve introducción: 
+
+Como se explica más abajo, la documentación oficial está en [Transbank developers](https://www.transbankdevelopers.cl/producto/posintegrado), pero como una breve introducción:
 
 ```javascript
 //Dependiendo del modelo de POS
-const { POSAutoservicio } = require('transbank-pos-sdk');
-const { POSIntegrado } = require('transbank-pos-sdk');
+const { POSAutoservicio } = require("transbank-pos-sdk");
+const { POSIntegrado } = require("transbank-pos-sdk");
 
 const pos = new POSIntegrado();
 pos.setDebug(true);
 
-pos.autoconnect() // Esta línea permite busca en todos los puertos si existe uno que tenga conectado un equipo POS y se intenta conectar con el primero que encuentra. 
+pos.autoconnect() // Esta línea permite busca en todos los puertos si existe uno que tenga conectado un equipo POS y se intenta conectar con el primero que encuentra.
     .then((port) => {
         if (port === false) {
-            console.log('No se encontró ningún POS conectado')
-        }  
+            console.log("No se encontró ningún POS conectado");
+        }
 
-        console.log('Connected to PORT: ', port.path)
-        pos.loadKeys() // Cargar llaves
+        console.log("Connected to PORT: ", port.path);
+        pos.loadKeys(); // Cargar llaves
     })
-    .catch((err) => { console.log('Ocurrió un error inesperado', err) })
-
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
-
 ### Métodos
+
 La mayoría de los métodos devuelve un `Promise` que al resolverse devuelve la respuesta del POS o el resultado de la operación
 
+#### Formato de respuestas
+
+Las respuestas de los métodos del SDK usan nombres de campos consistentes entre `POSIntegrado` y `POSAutoservicio`.
+
+Convenciones generales:
+
+- `success` indica si la operación fue aprobada.
+- `responseCode` contiene el código de respuesta retornado por el POS.
+- `responseMessage` contiene la glosa asociada al código de respuesta.
+- Los campos vacíos se retornan como `null`.
+- Los campos string se retornan sin espacios al inicio o al final.
+- `rawResponse` contiene la respuesta original del POS sin modificaciones.
+- `rawVoucher` contiene el voucher original sin modificaciones.
+- `printingField` contiene el voucher separado en líneas de 40 caracteres cuando aplica.
+
+Desde la versión 5 del SDK se han normalizado los nombres de los campos de respuesta:
+
+| Campo anterior       | Campo actual                  |
+| -------------------- | ----------------------------- |
+| `successful`         | `success`                     |
+| `voucher`            | `printingField`               |
+| `sharesType`         | `installmentsType`            |
+| `sharesNumber`       | `installmentsNumber`          |
+| `sharesAmount`       | `installmentsAmount`          |
+| `sharesTypeGloss`    | `installmentsTypeDescription` |
+| `lenderCommerceCode` | `commerceProviderCode`        |
+
+> `rawResponse` y `rawVoucher` son campos crudos: preservan el contenido original recibido desde el POS.
+
+---
+
 #### `setDebug(true/false)`
-Habilita/Deshabilita el que se imprima información de debug en la consola. 
+
+Habilita/Deshabilita el que se imprima información de debug en la consola.
+
 ```javascript
 pos.setDebug(true);
 ```
 
 #### `autoconnect()`
+
 Este método permite en un solo comando buscar un POS dentro de los puertos disponibles y conectarse automáticamente al primer POS que encuentre (en caso de haber más de uno)
+
 ```javascript
-pos.autoconnect().then( (response) => {
-    console.log(response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.autoconnect()
+    .then((response) => {
+        console.log(response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `listPorts()`
-Devuelve una lista de los puertos del computador disponibles para conectarse. 
+
+Devuelve una lista de los puertos del computador disponibles para conectarse.
+
 ```javascript
-pos.listPorts().then( (ports) => {
-    console.log(ports);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.listPorts()
+    .then((ports) => {
+        console.log(ports);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `connect(portName)`
-Este método permite en un solo comando buscar un POS dentro de los puertos disponibles y conectarse automáticamente al primer POS que encuentre (en caso de haber más de uno). 
+
+Este método permite en un solo comando buscar un POS dentro de los puertos disponibles y conectarse automáticamente al primer POS que encuentre (en caso de haber más de uno).
+
 ```javascript
-let portName = '/dev/tty.usb2412412'; //Ejemplo En caso de mac
-let portName = 'COM4'; //Ejempo en caso de windows
-pos.connect(portName).then( (response) => {
-    console.log('Conectado correctamente');
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+let portName = "/dev/tty.usb2412412"; //Ejemplo En caso de mac
+let portName = "COM4"; //Ejempo en caso de windows
+pos.connect(portName)
+    .then((response) => {
+        console.log("Conectado correctamente");
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `disconnect()`
-Desconectar (cerrar conexión serial) con el POS actualmente conectado.  
+
+Desconectar (cerrar conexión serial) con el POS actualmente conectado.
+
 ```javascript
-pos.disconnect().then( (response) => {
-    console.log('Puerto descontactado correctamente');
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.disconnect()
+    .then((response) => {
+        console.log("Puerto descontactado correctamente");
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `isConnected()`
+
 Devuelve `true` en caso de que exista una conexión activa con el POS y `false` en caso contrario
+
 ```javascript
 let connected = pos.isConnected();
 ```
 
 #### `getConnectedPort()`
-Devuelve el puerto al que se está conectado en caso de que exista una conexión activa con el POS y `false` en caso contrario. 
+
+Devuelve el puerto al que se está conectado en caso de que exista una conexión activa con el POS y `false` en caso contrario.
+
 ```javascript
 let connectedToPort = pos.getConnectedPort();
 ```
 
 #### `send(payload, waitResponse = true, callback = null)`
-Este comando, si bien es de uso interno, es posible usarlo públicamente y permite enviar un payload al POS. Este es el 
+
+Este comando, si bien es de uso interno, es posible usarlo públicamente y permite enviar un payload al POS. Este es el
 método que ocupan todos los siguientes helpers para comunicarse con el POS.
 
-Este método devuelve una promesa. Si `waitResponse` es `false` esta promesa se resuelve cuando el comando es recibido 
-correctamente por el POS (se recibe ack). Si `waitResponse`  es `true` la promesa se resuelve cuando llega un mensaje de 
-respuesta del POS (ejemplo, cuando la venta termina y el POS envía el resultado de esta venta).   
+Este método devuelve una promesa. Si `waitResponse` es `false` esta promesa se resuelve cuando el comando es recibido
+correctamente por el POS (se recibe ack). Si `waitResponse` es `true` la promesa se resuelve cuando llega un mensaje de
+respuesta del POS (ejemplo, cuando la venta termina y el POS envía el resultado de esta venta).
 
-`payload` es el mensaje a enviar. Puede ser un string (`"0200"`) o un Array de bytes en hexadecimal (`[0x20, 0x32, 0x10]`). 
- 
- Si `callback` es una función, esta se ejecutará cada vez que el POS envíe algo. Se usa para obtener los status intermedios de una venta que se envían antes de que llegue la respuesta final.  
-   
+`payload` es el mensaje a enviar. Puede ser un string (`"0200"`) o un Array de bytes en hexadecimal (`[0x20, 0x32, 0x10]`).
+
+Si `callback` es una función, esta se ejecutará cada vez que el POS envíe algo. Se usa para obtener los status intermedios de una venta que se envían antes de que llegue la respuesta final.
+
 ```javascript
-pos.send('0500||', false) // Cerrar día  con waitResponse false
-    .then( (response) => {
-        console.log('Comando enviado correctamente (se recibió ack del POS)', response);
-    }).catch( (err) => {
-        console.log('Ocurrió un error inesperado', err);
+pos.send("0500||", false) // Cerrar día  con waitResponse false
+    .then((response) => {
+        console.log(
+            "Comando enviado correctamente (se recibió ack del POS)",
+            response
+        );
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
     });
 
-pos.send('0500||', true) // Cerrar día con waitResponse true
-    .then( (response) => {
-        console.log('Respuesta recibida por el POS', response);
-    }).catch( (err) => {
-        console.log('Ocurrió un error inesperado', err);
+pos.send("0500||", true) // Cerrar día con waitResponse true
+    .then((response) => {
+        console.log("Respuesta recibida por el POS", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
     });
 ```
 
 #### `poll()`
-Ejecuta un comando `poll` en el POS. 
+
+Ejecuta un comando `poll` en el POS.
+
 ```javascript
-pos.poll().then( (response) => {
-    console.log('poll ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.poll()
+    .then((response) => {
+        console.log("poll ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `loadKeys()`
-Ejecuta un comando `loadKeys` en el POS. 
-```javascript
-pos.loadKeys().then( (response) => {
-    console.log('loadKeys ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
-```
 
+Ejecuta un comando `loadKeys` en el POS.
+
+```javascript
+pos.loadKeys()
+    .then((response) => {
+        console.log("loadKeys ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
+```
 
 #### `closeDay()`
-Ejecuta un comando `closeDay` en el POS. 
+
+Ejecuta un comando `closeDay` en el POS.
+
 ```javascript
-pos.closeDay().then( (response) => {
-    console.log('closeDay ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.closeDay()
+    .then((response) => {
+        console.log("closeDay ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
-
 #### `getLastSale()`
-Ejecuta un comando `getLastSale` en el POS. 
+
+Ejecuta un comando `getLastSale` en el POS.
+
 ```javascript
-pos.getLastSale().then( (response) => {
-    console.log('getLastSale ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.getLastSale()
+    .then((response) => {
+        console.log("getLastSale ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `getTotals()`
-Ejecuta un comando `getTotals` en el POS. 
+
+Ejecuta un comando `getTotals` en el POS.
+
 ```javascript
-pos.getTotals().then( (response) => {
-    console.log('getTotals ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.getTotals()
+    .then((response) => {
+        console.log("getTotals ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `salesDetail(printOnPos = false)`
-Obtiene detalle de las ventas del POS. `printOnPos` indica si se desea imprimir en papel el detalle de ventas en el POS. 
-Si `printOnPos` es true, el POS no enviará respuesta al computador y solo lo imprimirá, por lo que la promesa de 
-respuesta se ejecutará cuando llegue el ack de que el POS recibió el comando. En caso contrario, la promesa se resuelve 
-cuando llega la lista con todas las ventas. 
+
+Obtiene detalle de las ventas del POS. `printOnPos` indica si se desea imprimir en papel el detalle de ventas en el POS.
+Si `printOnPos` es true, el POS no enviará respuesta al computador y solo lo imprimirá, por lo que la promesa de
+respuesta se ejecutará cuando llegue el ack de que el POS recibió el comando. En caso contrario, la promesa se resuelve
+cuando llega la lista con todas las ventas.
+
 ```javascript
-pos.salesDetail().then( (response) => {
-    console.log('salesDetail ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.salesDetail()
+    .then((response) => {
+        console.log("salesDetail ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `refund(operationId)`
-Ejecuta un comando `refund` en el POS. `operationId` es el ID de la operación que se desea anular.  
+
+Ejecuta un comando `refund` en el POS. `operationId` es el ID de la operación que se desea anular.
+
 ```javascript
-pos.refund('102').then( (response) => {
-    console.log('refund ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.refund("102")
+    .then((response) => {
+        console.log("refund ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `changeToNormalMode()`
-Ejecuta un comando `changeToNormalMode` en el POS. 
+
+Ejecuta un comando `changeToNormalMode` en el POS.
+
 ```javascript
-pos.changeToNormalMode().then( (response) => {
-    console.log('changeToNormalMode ejecutado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.changeToNormalMode()
+    .then((response) => {
+        console.log("changeToNormalMode ejecutado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 #### `sale(amount, ticket, sendStatus = false, callback = null)`
-Ejecuta un comando `sale` en el POS.
-`amount` es el integer que representa el monto a pagar. `ticket` es un número de ticket  que te permita 
-referenciar la venta internamente. 
 
-Si `sendStatus` es `false` el POS solo enviará un mensaje cuando se termine el proceso de venta. Si `sendStatus` es 
-`false` el POS enviará mensajes a medida que se va avanzando en el proceso  (se selecciona método de pago, 
-el usuario pasa la tarjeta, se ingresa la clave, etc). Estos mensajes de estados intermedios se pueden capturar 
+Ejecuta un comando `sale` en el POS.
+`amount` es el integer que representa el monto a pagar. `ticket` es un número de ticket que te permita
+referenciar la venta internamente.
+
+Si `sendStatus` es `false` el POS solo enviará un mensaje cuando se termine el proceso de venta. Si `sendStatus` es
+`false` el POS enviará mensajes a medida que se va avanzando en el proceso (se selecciona método de pago,
+el usuario pasa la tarjeta, se ingresa la clave, etc). Estos mensajes de estados intermedios se pueden capturar
 definiendo una función en el parámetro `callback`
- 
+
 ```javascript
 // Venta simple sin estados intermedios
-pos.sale(1500, '12423').then( (response) => {
-    console.log('sale finalizado. Respuesta: ', response);
-}).catch( (err) => {
-    console.log('Ocurrió un error inesperado', err);
-});
+pos.sale(1500, "12423")
+    .then((response) => {
+        console.log("sale finalizado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 
 // Venta con estados intermedios
 let callback = function (data) {
-    console.log('Mensaje intermedio recibido:  ', data)
-}
-pos.sale(1500, '12423', true, callback)
-    .then( (response) => {
-        console.log('sale finalizado. Respuesta: ', response);
-    }).catch( (err) => {
-        console.log('Ocurrió un error inesperado', err);
-}); 
-
+    console.log("Mensaje intermedio recibido:  ", data);
+};
+pos.sale(1500, "12423", true, callback)
+    .then((response) => {
+        console.log("sale finalizado. Respuesta: ", response);
+    })
+    .catch((err) => {
+        console.log("Ocurrió un error inesperado", err);
+    });
 ```
 
 ### Proyecto de ejemplo
-El SDK Web de POS integrado está construido en Node.js, usando este SDK por debajo. [Puedes revisar el código acá](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent). 
 
-## Documentación 
+El SDK Web de POS integrado está construido en Node.js, usando este SDK por debajo. [Puedes revisar el código acá](https://github.com/TransbankDevelopers/transbank-pos-sdk-web-agent).
+
+## Documentación
 
 Puedes encontrar toda la documentación de cómo usar este SDK en el sitio https://www.transbankdevelopers.cl.
 
@@ -260,6 +358,7 @@ La documentación relevante para usar este SDK es:
 - Referencia detallada sobre [POSIntegrado](https://www.transbankdevelopers.cl/referencia/posintegrado).
 
 # Información para contribuir y desarrollar este SDK
+
 ## **Estándares generales**
 
 - Para los commits nos basamos en las siguientes normas: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits 👀
@@ -290,12 +389,11 @@ La documentación relevante para usar este SDK es:
 
 `chore` = Cambios en el build o herramientas auxiliares y librerías
 
-
 ## **Rules** 📖
 
-1️⃣ -  Si no se añaden test en el pull request, se debe añadir un video o gif mostrando que el cambio no afecta el funcionamiento.
+1️⃣ - Si no se añaden test en el pull request, se debe añadir un video o gif mostrando que el cambio no afecta el funcionamiento.
 
-2️⃣ -  El pull request debe tener 2 o más aprobaciones para poder mezclarse.
+2️⃣ - El pull request debe tener 2 o más aprobaciones para poder mezclarse.
 
 3️⃣ - Si un commit revierte un commit anterior deberá comenzar con "revert:" seguido del mensaje del commit anterior.
 

--- a/src/PosAutoservicio.js
+++ b/src/PosAutoservicio.js
@@ -106,7 +106,7 @@ module.exports = class POSAutoservicio extends POSBase {
                 operationId: normalizeEmptyField(chunks[5]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === 0,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -122,10 +122,10 @@ module.exports = class POSAutoservicio extends POSBase {
                 commerceCode: parseNumber(chunks[2]),
                 terminalId: normalizeEmptyField(chunks[3]),
                 printingField: chunks[4]?.match(/.{1,40}/g),
-                rawVoucher: normalizeEmptyField(chunks[4]),
+                rawVoucher: normalizeEmptyField(chunks[4], false),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === 0,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -151,7 +151,7 @@ module.exports = class POSAutoservicio extends POSBase {
                 transactionTime: normalizeEmptyField(chunks[3]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === SUCCESSFUL_INITIALIZATION_CODE,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -179,12 +179,12 @@ module.exports = class POSAutoservicio extends POSBase {
             realDate: normalizeEmptyField(chunks[13]),
             realTime: normalizeEmptyField(chunks[14]),
             printingField: chunks[15]?.match(/.{1,40}/g) ?? null,
-            rawVoucher: normalizeEmptyField(chunks[15]),
+            rawVoucher: normalizeEmptyField(chunks[15], false),
             installmentsType: parseNumber(chunks[16]),
             installmentsNumber: parseNumber(chunks[17]),
             installmentsAmount: parseNumber(chunks[18]),
             installmentsTypeDescription: normalizeEmptyField(chunks[19]),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         };
     }
 
@@ -212,12 +212,12 @@ module.exports = class POSAutoservicio extends POSBase {
             realTime: normalizeEmptyField(chunks[14]),
             commerceProviderCode: parseNumber(chunks[15]),
             printingField: chunks[16]?.match(/.{1,40}/g) ?? null,
-            rawVoucher: normalizeEmptyField(chunks[16]),
+            rawVoucher: normalizeEmptyField(chunks[16], false),
             installmentsType: parseNumber(chunks[17]),
             installmentsNumber: parseNumber(chunks[18]),
             installmentsAmount: parseNumber(chunks[19]),
             installmentsTypeDescription: normalizeEmptyField(chunks[20]),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         };
     }
 };

--- a/src/PosAutoservicio.js
+++ b/src/PosAutoservicio.js
@@ -159,19 +159,6 @@ module.exports = class POSAutoservicio extends POSBase {
     saleResponse(payload) {
         let chunks = payload.split("|");
         const responseCode = parseNumber(chunks[1]);
-        const success = responseCode === 0;
-
-        if (!success) {
-            return {
-                functionCode: normalizeEmptyField(
-                    chunks[0].replaceAll(/\D+/g, "")
-                ),
-                responseCode: responseCode,
-                responseMessage: this.getResponseMessage(responseCode),
-                success: success,
-                rawResponse: normalizeEmptyField(payload)
-            };
-        }
 
         return {
             functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
@@ -179,7 +166,7 @@ module.exports = class POSAutoservicio extends POSBase {
             responseMessage: this.getResponseMessage(responseCode),
             commerceCode: parseNumber(chunks[2]),
             terminalId: normalizeEmptyField(chunks[3]),
-            success: success,
+            success: responseCode === 0,
             ticket: normalizeEmptyField(chunks[4]),
             authorizationCode: normalizeEmptyField(chunks[5]),
             amount: parseNumber(chunks[6]),
@@ -204,25 +191,12 @@ module.exports = class POSAutoservicio extends POSBase {
     multicodeSaleResponse(payload) {
         const chunks = payload.split("|");
         const responseCode = parseNumber(chunks[1]);
-        const success = responseCode === 0;
-
-        if (!success) {
-            return {
-                functionCode: normalizeEmptyField(
-                    chunks[0].replaceAll(/\D+/g, "")
-                ),
-                responseCode: responseCode,
-                responseMessage: this.getResponseMessage(responseCode),
-                success: success,
-                rawResponse: normalizeEmptyField(payload)
-            };
-        }
 
         return {
             functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
             responseCode: responseCode,
             responseMessage: this.getResponseMessage(responseCode),
-            success: success,
+            success: responseCode === 0,
             commerceCode: parseNumber(chunks[2]),
             terminalId: normalizeEmptyField(chunks[3]),
             ticket: normalizeEmptyField(chunks[4]),

--- a/src/PosAutoservicio.js
+++ b/src/PosAutoservicio.js
@@ -183,7 +183,7 @@ module.exports = class POSAutoservicio extends POSBase {
             installmentsType: parseNumber(chunks[16]),
             installmentsNumber: parseNumber(chunks[17]),
             installmentsAmount: parseNumber(chunks[18]),
-            InstallmentsTypeDescription: normalizeEmptyField(chunks[19]),
+            installmentsTypeDescription: normalizeEmptyField(chunks[19]),
             rawResponse: normalizeEmptyField(payload)
         };
     }
@@ -216,7 +216,7 @@ module.exports = class POSAutoservicio extends POSBase {
             installmentsType: parseNumber(chunks[17]),
             installmentsNumber: parseNumber(chunks[18]),
             installmentsAmount: parseNumber(chunks[19]),
-            InstallmentsTypeDescription: normalizeEmptyField(chunks[20]),
+            installmentsTypeDescription: normalizeEmptyField(chunks[20]),
             rawResponse: normalizeEmptyField(payload)
         };
     }

--- a/src/PosAutoservicio.js
+++ b/src/PosAutoservicio.js
@@ -1,4 +1,5 @@
 const POSBase = require("./PosBase");
+const { normalizeEmptyField, parseNumber } = require("./helpers/fieldParser");
 const FUNCTION_CODE_SALE_REQUEST = "0200";
 const FUNCTION_CODE_MULTICODE_SALE_REQUEST = "0270";
 const SUCCESSFUL_INITIALIZATION_CODE = 90;
@@ -93,15 +94,19 @@ module.exports = class POSAutoservicio extends POSBase {
     refund() {
         return this.send(`1200`).then((data) => {
             let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0].replaceAll(/\D+/g, "")),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
-                authorizationCode: chunks[4].trim(),
-                operationId: chunks[5],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1]) === 0
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
+                responseCode: responseCode,
+                commerceCode: parseNumber(chunks[2]),
+                terminalId: normalizeEmptyField(chunks[3]),
+                authorizationCode: normalizeEmptyField(chunks[4].trim()),
+                operationId: normalizeEmptyField(chunks[5]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === 0,
+                rawResponse: normalizeEmptyField(data)
             };
         });
     }
@@ -110,14 +115,17 @@ module.exports = class POSAutoservicio extends POSBase {
         let voucher = sendVoucher ? "1" : "0";
         return this.send(`0500|${voucher}`).then((data) => {
             let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
-                voucher: chunks[4]?.match(/.{1,40}/g),
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1]) === 0
+                functionCode: normalizeEmptyField(chunks[0]),
+                responseCode: responseCode,
+                commerceCode: parseNumber(chunks[2]),
+                terminalId: normalizeEmptyField(chunks[3]),
+                printingField: chunks[4]?.match(/.{1,40}/g),
+                rawVoucher: normalizeEmptyField(chunks[4]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === 0,
+                rawResponse: normalizeEmptyField(data)
             };
         });
     }
@@ -135,103 +143,107 @@ module.exports = class POSAutoservicio extends POSBase {
     initializationResponse() {
         return this.send("0080").then((data) => {
             let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                transactionDate: chunks[2],
-                transactionTime: chunks[3],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful:
-                    Number.parseInt(chunks[1]) ===
-                    SUCCESSFUL_INITIALIZATION_CODE
+                functionCode: normalizeEmptyField(chunks[0]),
+                responseCode: responseCode,
+                transactionDate: normalizeEmptyField(chunks[2]),
+                transactionTime: normalizeEmptyField(chunks[3]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === SUCCESSFUL_INITIALIZATION_CODE,
+                rawResponse: normalizeEmptyField(data)
             };
         });
     }
 
     saleResponse(payload) {
         let chunks = payload.split("|");
-        const responseCode = Number.parseInt(chunks[1]);
-        const successful = responseCode === 0;
+        const responseCode = parseNumber(chunks[1]);
+        const success = responseCode === 0;
 
-        if (!successful) {
+        if (!success) {
             return {
-                functionCode: Number.parseInt(chunks[0].replaceAll(/\D+/g, "")),
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
                 responseCode: responseCode,
                 responseMessage: this.getResponseMessage(responseCode),
-                successful: successful
+                success: success,
+                rawResponse: normalizeEmptyField(payload)
             };
         }
 
-        let authorizationCode =
-            chunks[5] === undefined ? null : chunks[5].trim();
-
-        let response = {
-            functionCode: Number.parseInt(chunks[0].replaceAll(/\D+/g, "")),
+        return {
+            functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
             responseCode: responseCode,
             responseMessage: this.getResponseMessage(responseCode),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            successful: successful,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            last4Digits: chunks[7] ? Number.parseInt(chunks[7]) : null,
-            operationNumber: chunks[8],
-            cardType: chunks[9],
-            accountingDate: chunks[10],
-            accountNumber: chunks[11],
-            cardBrand: chunks[12],
-            realDate: chunks[13],
-            realTime: chunks[14],
-            voucher: chunks[15]?.match(/.{1,40}/g),
-            sharesType: chunks[16],
-            sharesNumber: chunks[17],
-            sharesAmount: chunks[18],
-            sharesTypeGloss: chunks[19]
+            commerceCode: parseNumber(chunks[2]),
+            terminalId: normalizeEmptyField(chunks[3]),
+            success: success,
+            ticket: normalizeEmptyField(chunks[4]),
+            authorizationCode: normalizeEmptyField(chunks[5]),
+            amount: parseNumber(chunks[6]),
+            last4Digits: chunks[7] ? parseNumber(chunks[7]) : null,
+            operationNumber: parseNumber(chunks[8]),
+            cardType: normalizeEmptyField(chunks[9]),
+            accountingDate: normalizeEmptyField(chunks[10]),
+            accountNumber: normalizeEmptyField(chunks[11]),
+            cardBrand: normalizeEmptyField(chunks[12]),
+            realDate: normalizeEmptyField(chunks[13]),
+            realTime: normalizeEmptyField(chunks[14]),
+            printingField: chunks[15]?.match(/.{1,40}/g) ?? null,
+            rawVoucher: normalizeEmptyField(chunks[15]),
+            installmentsType: parseNumber(chunks[16]),
+            installmentsNumber: parseNumber(chunks[17]),
+            installmentsAmount: parseNumber(chunks[18]),
+            InstallmentsTypeDescription: normalizeEmptyField(chunks[19]),
+            rawResponse: normalizeEmptyField(payload)
         };
-        return response;
     }
 
     multicodeSaleResponse(payload) {
         const chunks = payload.split("|");
-        const responseCode = Number.parseInt(chunks[1]);
-        const successful = responseCode === 0;
+        const responseCode = parseNumber(chunks[1]);
+        const success = responseCode === 0;
 
-        if (!successful) {
+        if (!success) {
             return {
-                functionCode: Number.parseInt(chunks[0].replaceAll(/\D+/g, "")),
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
                 responseCode: responseCode,
                 responseMessage: this.getResponseMessage(responseCode),
-                successful: successful
+                success: success,
+                rawResponse: normalizeEmptyField(payload)
             };
         }
-        let authorizationCode =
-            chunks[5] === undefined ? null : chunks[5].trim();
 
         return {
-            functionCode: Number.parseInt(chunks[0].replaceAll(/\D+/g, "")),
+            functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
             responseCode: responseCode,
             responseMessage: this.getResponseMessage(responseCode),
-            successful: successful,
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            last4Digits: chunks[7] ? Number.parseInt(chunks[7]) : null,
-            operationNumber: chunks[8],
-            cardType: chunks[9],
-            accountingDate: chunks[10],
-            accountNumber: chunks[11],
-            cardBrand: chunks[12],
-            realDate: chunks[13],
-            realTime: chunks[14],
-            lenderCommerceCode: Number.parseInt(chunks[15]),
+            success: success,
+            commerceCode: parseNumber(chunks[2]),
+            terminalId: normalizeEmptyField(chunks[3]),
+            ticket: normalizeEmptyField(chunks[4]),
+            authorizationCode: normalizeEmptyField(chunks[5]),
+            amount: parseNumber(chunks[6]),
+            last4Digits: parseNumber(chunks[7]),
+            operationNumber: parseNumber(chunks[8]),
+            cardType: normalizeEmptyField(chunks[9]),
+            accountingDate: normalizeEmptyField(chunks[10]),
+            accountNumber: normalizeEmptyField(chunks[11]),
+            cardBrand: normalizeEmptyField(chunks[12]),
+            realDate: normalizeEmptyField(chunks[13]),
+            realTime: normalizeEmptyField(chunks[14]),
+            commerceProviderCode: parseNumber(chunks[15]),
             printingField: chunks[16]?.match(/.{1,40}/g) ?? null,
-            sharesType: chunks[17] ?? null,
-            sharesNumber: chunks[18] ?? null,
-            sharesAmount: chunks[19] ?? null,
-            sharesTypeGloss: chunks[20] ?? null
+            rawVoucher: normalizeEmptyField(chunks[16]),
+            installmentsType: parseNumber(chunks[17]),
+            installmentsNumber: parseNumber(chunks[18]),
+            installmentsAmount: parseNumber(chunks[19]),
+            InstallmentsTypeDescription: normalizeEmptyField(chunks[20]),
+            rawResponse: normalizeEmptyField(payload)
         };
     }
 };

--- a/src/PosAutoservicio.js
+++ b/src/PosAutoservicio.js
@@ -170,7 +170,7 @@ module.exports = class POSAutoservicio extends POSBase {
             ticket: normalizeEmptyField(chunks[4]),
             authorizationCode: normalizeEmptyField(chunks[5]),
             amount: parseNumber(chunks[6]),
-            last4Digits: chunks[7] ? parseNumber(chunks[7]) : null,
+            last4Digits: parseNumber(chunks[7]),
             operationNumber: parseNumber(chunks[8]),
             cardType: normalizeEmptyField(chunks[9]),
             accountingDate: normalizeEmptyField(chunks[10]),

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -350,7 +350,7 @@ module.exports = class POSBase extends EventEmitter {
                 terminalId: normalizeEmptyField(chunks[3]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === SUCCESSFUL_RESPONSE_CODE,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             }
         })
     }
@@ -360,7 +360,7 @@ module.exports = class POSBase extends EventEmitter {
         let response = {
             responseCode: parseNumber(chunks[1]),
             responseMessage: this.getResponseMessage(parseNumber(chunks[1])),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         }
 
         return response;

--- a/src/PosBase.js
+++ b/src/PosBase.js
@@ -3,9 +3,11 @@ const { SerialPort } = require("serialport")
 const EventEmitter = require('events');
 const { InterByteTimeoutParser } = require("@serialport/parser-inter-byte-timeout")
 const responseMessages = require("./responseCodes");
+const { normalizeEmptyField, parseNumber } = require("./helpers/fieldParser");
 const ACK = 0x06
 const FUNCTION_CODE_INTERMEDIATE_MESSAGE = "0900";
 const FUNCTION_CODE_SALES_DETAIL_RESPONSE = "0261";
+const SUCCESSFUL_RESPONSE_CODE = 0;
 
 module.exports = class POSBase extends EventEmitter {
 
@@ -340,13 +342,15 @@ module.exports = class POSBase extends EventEmitter {
     loadKeys() {
         return this.send("0800").then((data) => {
             let chunks = data.split("|")
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: parseInt(chunks[0]),
-                responseCode: parseInt(chunks[1]),
-                commerceCode: parseInt(chunks[2]),
-                terminalId: chunks[3],
-                responseMessage: this.getResponseMessage(parseInt(chunks[1])),
-                successful: parseInt(chunks[1])===0
+                functionCode: normalizeEmptyField(chunks[0]),
+                responseCode: responseCode,
+                commerceCode: parseNumber(chunks[2]),
+                terminalId: normalizeEmptyField(chunks[3]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === SUCCESSFUL_RESPONSE_CODE,
+                rawResponse: normalizeEmptyField(data)
             }
         })
     }
@@ -354,8 +358,9 @@ module.exports = class POSBase extends EventEmitter {
     intermediateResponse(payload) {
         let chunks = payload.split("|")
         let response = {
-            responseCode: parseInt(chunks[1]),
-            responseMessage: this.getResponseMessage(parseInt(chunks[1]))
+            responseCode: parseNumber(chunks[1]),
+            responseMessage: this.getResponseMessage(parseNumber(chunks[1])),
+            rawResponse: normalizeEmptyField(payload)
         }
 
         return response;

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -107,14 +107,10 @@ module.exports = class POSIntegrado extends POSBase {
                     sales.push(detail);
                 }
 
-                if (
+                return (
                     consecutiveEmptyAuthCodes >=
                     CONSECUTIVE_EMPTY_AUTHCODE_LIMIT
-                ) {
-                    return true;
-                }
-
-                return false;
+                );
             };
 
             this.send(command, true, processDetailResponse)

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -124,7 +124,7 @@ module.exports = class POSIntegrado extends POSBase {
     }
 
     refund(operationId) {
-        if (typeof operationId === "undefined") {
+        if (operationId === undefined) {
             throw new Error(
                 "Operation ID not provided when calling refund method."
             );

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -1,12 +1,11 @@
-const POSBase = require('./PosBase');
+const POSBase = require("./PosBase");
 const { normalizeEmptyField, parseNumber } = require("./helpers/fieldParser");
-const FUNCTION_CODE_MULTICODE_SALE_REQUEST = '0270';
-const FUNCTION_CODE_SALE_REQUEST = '0200';
+const FUNCTION_CODE_MULTICODE_SALE_REQUEST = "0270";
+const FUNCTION_CODE_SALE_REQUEST = "0200";
 const CONSECUTIVE_EMPTY_AUTHCODE_LIMIT = 2;
 const SUCCESSFUL_RESPONSE_CODE = 0;
 
 module.exports = class POSIntegrado extends POSBase {
-
     /*
      |--------------------------------------------------------------------------
      | Auxiliary Methods
@@ -25,61 +24,70 @@ module.exports = class POSIntegrado extends POSBase {
 
     closeDay() {
         return this.send("0500||").then((data) => {
-            let chunks = data.split("|")
+            let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
-                responseMessage: this.getResponseMessage (Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
+                responseCode: responseCode,
+                commerceCode: parseNumber(chunks[2]),
+                terminalId: normalizeEmptyField(chunks[3]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === 0,
+                rawResponse: normalizeEmptyField(data)
+            };
+        });
     }
 
     getLastSale() {
         return this.send("0250|").then((data) => {
             try {
-                return this.lastSaleResponse(data)
+                return this.lastSaleResponse(data);
             } catch (e) {
-                throw new Error(e.getMessage())
+                throw new Error(e.getMessage());
             }
-
-        })
+        });
     }
 
     getTotals() {
         return this.send("0700||").then((data) => {
-            let chunks = data.split("|")
+            let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                txCount: Number.parseInt(chunks[2]),
-                txTotal: Number.parseInt(chunks[3]),
-                responseMessage: this.getResponseMessage (Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
+                responseCode: responseCode,
+                txCount: parseNumber(chunks[2]),
+                txTotal: parseNumber(chunks[3]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === 0,
+                rawResponse: normalizeEmptyField(data)
+            };
+        });
     }
 
     salesDetail(printOnPos = false) {
         return new Promise((resolve, reject) => {
-
-            if(typeof printOnPos !== 'boolean' && typeof printOnPos !== 'string') {
-                return reject(new Error("printOnPos must be of type boolean."))
+            if (
+                typeof printOnPos !== "boolean" &&
+                typeof printOnPos !== "string"
+            ) {
+                return reject(new Error("printOnPos must be of type boolean."));
             }
 
-            if(typeof printOnPos === 'string') {
-                printOnPos = (printOnPos === 'true' || printOnPos === '1')
+            if (typeof printOnPos === "string") {
+                printOnPos = printOnPos === "true" || printOnPos === "1";
             }
 
-            let print = printOnPos ? "0":"1"
+            let print = printOnPos ? "0" : "1";
 
             if (printOnPos) {
-                    this.send(`0260|${print}|`, false)
-                        .then(() => resolve(true))
-                        .catch(reject);
-                    return;
+                this.send(`0260|${print}|`, false)
+                    .then(() => resolve(true))
+                    .catch(reject);
+                return;
             }
 
             let sales = [];
@@ -89,14 +97,20 @@ module.exports = class POSIntegrado extends POSBase {
             const processDetailResponse = (responsePayload) => {
                 let detail = this.saleDetailResponse(responsePayload);
 
-                if (detail.authorizationCode === "" || detail.authorizationCode === null) {
+                if (
+                    detail.authorizationCode === "" ||
+                    detail.authorizationCode === null
+                ) {
                     consecutiveEmptyAuthCodes++;
                 } else {
                     consecutiveEmptyAuthCodes = 0;
                     sales.push(detail);
                 }
 
-                if (consecutiveEmptyAuthCodes >= CONSECUTIVE_EMPTY_AUTHCODE_LIMIT) {;
+                if (
+                    consecutiveEmptyAuthCodes >=
+                    CONSECUTIVE_EMPTY_AUTHCODE_LIMIT
+                ) {
                     return true;
                 }
 
@@ -107,60 +121,100 @@ module.exports = class POSIntegrado extends POSBase {
                 .then(() => {
                     resolve(sales);
                 })
-                .catch(error => {
+                .catch((error) => {
                     reject(error);
                 });
         });
     }
 
     refund(operationId) {
-        if (typeof operationId==="undefined") {
-            throw new Error("Operation ID not provided when calling refund method.")
+        if (typeof operationId === "undefined") {
+            throw new Error(
+                "Operation ID not provided when calling refund method."
+            );
         }
 
-        operationId = operationId.toString().slice(0, 6)
+        operationId = operationId.toString().slice(0, 6);
         return this.send(`1200|${operationId}|`).then((data) => {
-            let chunks = data.split("|")
+            let chunks = data.split("|");
+            const responseCode = parseNumber(chunks[1]);
             return {
-                functionCode: Number.parseInt(chunks[0]),
-                responseCode: Number.parseInt(chunks[1]),
-                commerceCode: Number.parseInt(chunks[2]),
-                terminalId: chunks[3],
-                authorizationCode: chunks[4].trim(),
-                operationId: chunks[5],
-                responseMessage: this.getResponseMessage (Number.parseInt(chunks[1])),
-                successful: Number.parseInt(chunks[1])===0
-            }
-        })
+                functionCode: normalizeEmptyField(
+                    chunks[0].replaceAll(/\D+/g, "")
+                ),
+                responseCode: responseCode,
+                commerceCode: parseNumber(chunks[2]),
+                terminalId: normalizeEmptyField(chunks[3]),
+                authorizationCode: normalizeEmptyField(chunks[4].trim()),
+                operationId: parseNumber(chunks[5]),
+                responseMessage: this.getResponseMessage(responseCode),
+                success: responseCode === 0,
+                rawResponse: normalizeEmptyField(data)
+            };
+        });
     }
 
     changeToNormalMode() {
-        return this.send("0300", false)
+        return this.send("0300", false);
     }
 
-    buildSaleCommand(functionCode, amount, ticket, sendStatus, sendVoucher, commerceCode = null) {
+    buildSaleCommand(
+        functionCode,
+        amount,
+        ticket,
+        sendStatus,
+        sendVoucher,
+        commerceCode = null
+    ) {
         const statusStr = this.getBooleanFlag(sendStatus);
         const voucherStr = this.getBooleanFlag(sendVoucher);
 
         let command = `${functionCode}|${amount}|${ticket}||${voucherStr}|${statusStr}`;
 
         if (functionCode === FUNCTION_CODE_MULTICODE_SALE_REQUEST) {
-            const code = commerceCode && commerceCode !== '0' ? commerceCode : '';
+            const code =
+                commerceCode && commerceCode !== "0" ? commerceCode : "";
             command += `|${code}|`;
         }
-        
+
         return command;
     }
 
-    sale(amount, ticket, sendStatus = false, sendVoucher = false, callback = null) {
-        const command = this.buildSaleCommand(FUNCTION_CODE_SALE_REQUEST, amount, ticket, sendStatus, sendVoucher);
+    sale(
+        amount,
+        ticket,
+        sendStatus = false,
+        sendVoucher = false,
+        callback = null
+    ) {
+        const command = this.buildSaleCommand(
+            FUNCTION_CODE_SALE_REQUEST,
+            amount,
+            ticket,
+            sendStatus,
+            sendVoucher
+        );
         return this.send(command, true, callback).then((data) => {
             return this.saleResponse(data);
         });
     }
 
-    multicodeSale(amount, ticket, commerceCode = null, sendStatus = false, sendVoucher = false, callback = null) {
-        const command = this.buildSaleCommand(FUNCTION_CODE_MULTICODE_SALE_REQUEST, amount, ticket, sendStatus, sendVoucher, commerceCode);
+    multicodeSale(
+        amount,
+        ticket,
+        commerceCode = null,
+        sendStatus = false,
+        sendVoucher = false,
+        callback = null
+    ) {
+        const command = this.buildSaleCommand(
+            FUNCTION_CODE_MULTICODE_SALE_REQUEST,
+            amount,
+            ticket,
+            sendStatus,
+            sendVoucher,
+            commerceCode
+        );
         return this.send(command, true, callback).then((data) => {
             return this.multicodeSaleResponse(data);
         });
@@ -172,8 +226,8 @@ module.exports = class POSIntegrado extends POSBase {
      |--------------------------------------------------------------------------
      */
 
-     saleDetailResponse(payload) {
-        let chunks = payload.split("|")
+    saleDetailResponse(payload) {
+        let chunks = payload.split("|");
         const responseCode = parseNumber(chunks[1]);
 
         return {
@@ -182,7 +236,7 @@ module.exports = class POSIntegrado extends POSBase {
             commerceCode: parseNumber(chunks[2]),
             terminalId: normalizeEmptyField(chunks[3]),
             responseMessage: this.getResponseMessage(responseCode),
-            successful: responseCode === SUCCESSFUL_RESPONSE_CODE,
+            success: responseCode === SUCCESSFUL_RESPONSE_CODE,
             ticket: normalizeEmptyField(chunks[4]),
             authorizationCode: normalizeEmptyField(chunks[5]),
             amount: parseNumber(chunks[6]),
@@ -197,93 +251,21 @@ module.exports = class POSIntegrado extends POSBase {
             employeeId: parseNumber(chunks[15]),
             tip: parseNumber(chunks[16]),
             installmentsAmount: parseNumber(chunks[17]),
-            installmentsNumber: parseNumber(chunks[18])
-        }
+            installmentsNumber: parseNumber(chunks[18]),
+            rawResponse: normalizeEmptyField(payload)
+        };
     }
 
     saleResponse(payload) {
         const chunks = payload.split("|");
-        const authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-        const response = {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage (Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] !== '' ? Number.parseInt(chunks[18]) : null,
-            voucher: null
-        }
-        
-        if (chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g);
-        }
-
-        return response;
-    }
-
-    multicodeSaleResponse(payload) {
-        const chunks = payload.split("|");
-        const authorizationCode = typeof chunks[5] !== 'undefined' ? chunks[5].trim() : null;
-        const response = {
-            functionCode: Number.parseInt(chunks[0]),
-            responseCode: Number.parseInt(chunks[1]),
-            commerceCode: Number.parseInt(chunks[2]),
-            terminalId: chunks[3],
-            responseMessage: this.getResponseMessage (Number.parseInt(chunks[1])),
-            successful: Number.parseInt(chunks[1])===0,
-            ticket: chunks[4],
-            authorizationCode: authorizationCode,
-            amount: Number.parseInt(chunks[6]),
-            sharesNumber: chunks[7],
-            sharesAmount: chunks[8],
-            last4Digits: chunks[9] !== '' ? Number.parseInt(chunks[9]) : null,
-            operationNumber: chunks[10],
-            cardType: chunks[11],
-            accountingDate: chunks[12],
-            accountNumber: chunks[13],
-            cardBrand: chunks[14],
-            realDate: chunks[15],
-            realTime: chunks[16],
-            employeeId: chunks[17],
-            tip: chunks[18] !== '' ? Number.parseInt(chunks[18]) : null,
-            voucher: null,
-            change: chunks[20],
-            lenderCommerceCode: Number.parseInt(chunks[21])
-        }
-
-        if (chunks[19] && chunks[19].length > 1) {
-            response.voucher = chunks[19]?.match(/.{1,40}/g);
-        }
-
-        return response
-    }
-
-    lastSaleResponse(payload) {
-        const chunks = payload.split("|");
         const responseCode = parseNumber(chunks[1]);
-
         return {
-            functionCode: normalizeEmptyField(chunks[0]),
+            functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
             responseCode: responseCode,
             commerceCode: parseNumber(chunks[2]),
             terminalId: normalizeEmptyField(chunks[3]),
             responseMessage: this.getResponseMessage(responseCode),
-            successful: responseCode === SUCCESSFUL_RESPONSE_CODE,
+            success: responseCode === 0,
             ticket: normalizeEmptyField(chunks[4]),
             authorizationCode: normalizeEmptyField(chunks[5]),
             amount: parseNumber(chunks[6]),
@@ -298,8 +280,75 @@ module.exports = class POSIntegrado extends POSBase {
             realDate: normalizeEmptyField(chunks[15]),
             realTime: normalizeEmptyField(chunks[16]),
             employeeId: parseNumber(chunks[17]),
-            tip: parseNumber(chunks[18])
+            tip: parseNumber(chunks[18]),
+            printingField: chunks[19]?.match(/.{1,40}/g) ?? null,
+            rawVoucher: normalizeEmptyField(chunks[19]),
+            rawResponse: normalizeEmptyField(payload)
         };
     }
 
-}
+    multicodeSaleResponse(payload) {
+        const chunks = payload.split("|");
+        const responseCode = parseNumber(chunks[1]);
+        const response = {
+            functionCode: normalizeEmptyField(chunks[0].replaceAll(/\D+/g, "")),
+            responseCode: responseCode,
+            commerceCode: parseNumber(chunks[2]),
+            terminalId: normalizeEmptyField(chunks[3]),
+            responseMessage: this.getResponseMessage(responseCode),
+            success: responseCode === 0,
+            ticket: normalizeEmptyField(chunks[4]),
+            authorizationCode: normalizeEmptyField(chunks[5]),
+            amount: parseNumber(chunks[6]),
+            installmentsNumber: parseNumber(chunks[7]),
+            installmentsAmount: parseNumber(chunks[8]),
+            last4Digits: parseNumber(chunks[9]),
+            operationNumber: parseNumber(chunks[10]),
+            cardType: normalizeEmptyField(chunks[11]),
+            accountingDate: normalizeEmptyField(chunks[12]),
+            accountNumber: normalizeEmptyField(chunks[13]),
+            cardBrand: normalizeEmptyField(chunks[14]),
+            realDate: normalizeEmptyField(chunks[15]),
+            realTime: normalizeEmptyField(chunks[16]),
+            employeeId: parseNumber(chunks[17]),
+            tip: parseNumber(chunks[18]),
+            printingField: chunks[19]?.match(/.{1,40}/g) ?? null,
+            rawVoucher: normalizeEmptyField(chunks[19]),
+            change: parseNumber(chunks[20]),
+            commerceProviderCode: parseNumber(chunks[21]),
+            rawResponse: normalizeEmptyField(payload)
+        };
+
+        return response;
+    }
+
+    lastSaleResponse(payload) {
+        const chunks = payload.split("|");
+        const responseCode = parseNumber(chunks[1]);
+
+        return {
+            functionCode: normalizeEmptyField(chunks[0]),
+            responseCode: responseCode,
+            commerceCode: parseNumber(chunks[2]),
+            terminalId: normalizeEmptyField(chunks[3]),
+            responseMessage: this.getResponseMessage(responseCode),
+            success: responseCode === SUCCESSFUL_RESPONSE_CODE,
+            ticket: normalizeEmptyField(chunks[4]),
+            authorizationCode: normalizeEmptyField(chunks[5]),
+            amount: parseNumber(chunks[6]),
+            installmentsNumber: parseNumber(chunks[7]),
+            installmentsAmount: parseNumber(chunks[8]),
+            last4Digits: parseNumber(chunks[9]),
+            operationNumber: parseNumber(chunks[10]),
+            cardType: normalizeEmptyField(chunks[11]),
+            accountingDate: normalizeEmptyField(chunks[12]),
+            accountNumber: normalizeEmptyField(chunks[13]),
+            cardBrand: normalizeEmptyField(chunks[14]),
+            realDate: normalizeEmptyField(chunks[15]),
+            realTime: normalizeEmptyField(chunks[16]),
+            employeeId: parseNumber(chunks[17]),
+            tip: parseNumber(chunks[18]),
+            rawResponse: normalizeEmptyField(payload)
+        };
+    }
+};

--- a/src/PosIntegrado.js
+++ b/src/PosIntegrado.js
@@ -35,7 +35,7 @@ module.exports = class POSIntegrado extends POSBase {
                 terminalId: normalizeEmptyField(chunks[3]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === 0,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -63,7 +63,7 @@ module.exports = class POSIntegrado extends POSBase {
                 txTotal: parseNumber(chunks[3]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === 0,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -149,7 +149,7 @@ module.exports = class POSIntegrado extends POSBase {
                 operationId: parseNumber(chunks[5]),
                 responseMessage: this.getResponseMessage(responseCode),
                 success: responseCode === 0,
-                rawResponse: normalizeEmptyField(data)
+                rawResponse: normalizeEmptyField(data, false)
             };
         });
     }
@@ -252,7 +252,7 @@ module.exports = class POSIntegrado extends POSBase {
             tip: parseNumber(chunks[16]),
             installmentsAmount: parseNumber(chunks[17]),
             installmentsNumber: parseNumber(chunks[18]),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         };
     }
 
@@ -282,8 +282,8 @@ module.exports = class POSIntegrado extends POSBase {
             employeeId: parseNumber(chunks[17]),
             tip: parseNumber(chunks[18]),
             printingField: chunks[19]?.match(/.{1,40}/g) ?? null,
-            rawVoucher: normalizeEmptyField(chunks[19]),
-            rawResponse: normalizeEmptyField(payload)
+            rawVoucher: normalizeEmptyField(chunks[19], false),
+            rawResponse: normalizeEmptyField(payload, false)
         };
     }
 
@@ -313,10 +313,10 @@ module.exports = class POSIntegrado extends POSBase {
             employeeId: parseNumber(chunks[17]),
             tip: parseNumber(chunks[18]),
             printingField: chunks[19]?.match(/.{1,40}/g) ?? null,
-            rawVoucher: normalizeEmptyField(chunks[19]),
+            rawVoucher: normalizeEmptyField(chunks[19], false),
             change: parseNumber(chunks[20]),
             commerceProviderCode: parseNumber(chunks[21]),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         };
 
         return response;
@@ -348,7 +348,7 @@ module.exports = class POSIntegrado extends POSBase {
             realTime: normalizeEmptyField(chunks[16]),
             employeeId: parseNumber(chunks[17]),
             tip: parseNumber(chunks[18]),
-            rawResponse: normalizeEmptyField(payload)
+            rawResponse: normalizeEmptyField(payload, false)
         };
     }
 };

--- a/src/helpers/fieldParser.js
+++ b/src/helpers/fieldParser.js
@@ -1,8 +1,16 @@
 const INTEGER_PATTERN = /^-?\d+$/;
 
-const normalizeEmptyField = (value) => {
+const normalizeEmptyField = (value, trim = true) => {
     if (value === undefined || value === null || value === "") {
         return null;
+    }
+
+    if (trim) {
+        const trimmedValue = value.trim();
+        if (trimmedValue === "") {
+            return null;
+        }
+        return trimmedValue;
     }
 
     return value;

--- a/tests/e2e/Autoservicio/pos.autoservicio.close.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.close.e2e.spec.js
@@ -11,20 +11,18 @@ const {
 const {
     closeWithDataVoucher,
     closeWithoutDataVoucher
- } = require("../helpers/autoservicioVoucherFixtures");
+} = require("../helpers/autoservicioVoucherFixtures");
 
 const createConnectedPos = async (suite) => {
     const pos = suite.createAutoservicio();
     await connectWithPollAck(pos);
     return pos;
-}
+};
 
 const closeWithDataVoucherResponsePayload =
-            "0510|00|597029414300|IM750164|" +
-            closeWithDataVoucher;
+    "0510|00|597029414300|IM750164|" + closeWithDataVoucher;
 const closeWithoutDataVoucherResponsePayload =
-            "0510|00|597029414300|IM750164|" +
-            closeWithoutDataVoucher;
+    "0510|00|597029414300|IM750164|" + closeWithoutDataVoucher;
 
 describe("POS Autoservicio - Close day transaction", () => {
     const suite = setupSuiteContext();
@@ -37,23 +35,25 @@ describe("POS Autoservicio - Close day transaction", () => {
         await sendReply(pos, ACK_BYTE);
         await sendReply(pos, closeWithDataVoucherResponsePayload);
         const response = await closePromise;
-        const voucherText = response.voucher.join('\n');
+        const voucherText = response.printingField.join("\n");
 
         expect(sentMessage).toEqual(buildMessage("0500|1"));
-        expect(response.voucher.every(line => line.length === 40)).toBe(true);
+        expect(response.printingField.every((line) => line.length === 40)).toBe(
+            true
+        );
         expect(voucherText).toContain("REPORTE DEL CIERRE DEL TERMINAL");
         expect(voucherText).toContain("NUMERO              TOTAL");
         expect(voucherText).toContain("VISA");
         expect(voucherText).toContain("TOTAL CAPTURAS");
         expect(voucherText).toContain("$20.000");
-
+        expect(response.rawResponse).toBe(closeWithDataVoucherResponsePayload);
         expectResponseFields(response, {
-            functionCode: 510,
+            functionCode: "0510",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IM750164",
             responseMessage: "Aprobado",
-            successful: true
+            success: true
         });
     });
 
@@ -68,13 +68,13 @@ describe("POS Autoservicio - Close day transaction", () => {
 
         expect(sentMessage).toEqual(buildMessage("0500|0"));
         expectResponseFields(response, {
-            functionCode: 510,
+            functionCode: "0510",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IM750164",
             responseMessage: "Aprobado",
-            voucher: null,
-            successful: true
+            printingField: null,
+            success: true
         });
     });
 
@@ -86,10 +86,12 @@ describe("POS Autoservicio - Close day transaction", () => {
         await sendReply(pos, ACK_BYTE);
         await sendReply(pos, closeWithoutDataVoucherResponsePayload);
         const response = await closePromise;
-        const voucherText = response.voucher.join('\n');
+        const voucherText = response.printingField.join("\n");
 
         expect(sentMessage).toEqual(buildMessage("0500|1"));
-        expect(response.voucher.every(line => line.length === 40)).toBe(true);
+        expect(response.printingField.every((line) => line.length === 40)).toBe(
+            true
+        );
         expect(voucherText).toContain("REPORTE DEL CIERRE DEL TERMINAL");
         expect(voucherText).toContain("NUMERO              TOTAL");
         expect(voucherText).not.toContain("VISA");
@@ -97,19 +99,18 @@ describe("POS Autoservicio - Close day transaction", () => {
         expect(voucherText).toContain("$0");
 
         expectResponseFields(response, {
-            functionCode: 510,
+            functionCode: "0510",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IM750164",
             responseMessage: "Aprobado",
-            successful: true
+            success: true
         });
     });
 
     it("closes day and parses approved response without voucher when there are no transactions", async () => {
-
         const pos = await createConnectedPos(suite);
-        
+
         const closePromise = pos.closeDay();
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
@@ -118,12 +119,12 @@ describe("POS Autoservicio - Close day transaction", () => {
         const response = await closePromise;
 
         expectResponseFields(response, {
-            functionCode: 510,
+            functionCode: "0510",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IM750164",
             responseMessage: "Aprobado",
-            successful: true
+            success: true
         });
     });
 });

--- a/tests/e2e/Autoservicio/pos.autoservicio.initialization.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.initialization.e2e.spec.js
@@ -12,7 +12,7 @@ const createConnectedPos = async (suite) => {
     const pos = suite.createAutoservicio();
     await connectWithPollAck(pos);
     return pos;
-}
+};
 
 describe("POS Autoservicio - Initialization", () => {
     const suite = setupSuiteContext();
@@ -32,18 +32,20 @@ describe("POS Autoservicio - Initialization", () => {
 
         const promise = pos.initializationResponse();
         const sentMessage = await captureSend(pos);
+        const posResponse = "1080|90|16022026|103654";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "1080|90|16022026|103654");
+        await sendReply(pos, posResponse);
         const response = await promise;
-        
+
+        expect(response.rawResponse).toBe(posResponse);
         expect(sentMessage).toEqual(buildMessage("0080"));
         expectResponseFields(response, {
-            functionCode: 1080,
+            functionCode: "1080",
             responseCode: 90,
             responseMessage: "Inicialización exitosa",
             transactionDate: "16022026",
             transactionTime: "103654",
-            successful: true
+            success: true
         });
     });
 });

--- a/tests/e2e/Autoservicio/pos.autoservicio.lastsale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.lastsale.e2e.spec.js
@@ -7,7 +7,7 @@ const {
     connectWithPollAck
 } = require("../helpers/mockPos");
 
-const { 
+const {
     validateBaseSaleFields,
     validateSaleFields,
     validateSharesFields,
@@ -18,21 +18,21 @@ const {
 const {
     lastSaleDebitVoucher,
     lastSaleCreditVoucher
- } = require("../helpers/autoservicioVoucherFixtures");
+} = require("../helpers/autoservicioVoucherFixtures");
 
 const createConnectedPos = async (suite) => {
     const pos = suite.createAutoservicio();
     await connectWithPollAck(pos);
     return pos;
-}
+};
 
 const lastSaleDebitWithVoucherResponsePayload =
-            "0260|00|597029414303|IM750164|123456|912108|1000|3331|68|DB|00-00-00|331|P |19032026|102438|" +
-            lastSaleDebitVoucher;
+    "0260|00|597029414303|IM750164|123456|912108|1000|3331|68|DB|00-00-00|331|P |19032026|102438|" +
+    lastSaleDebitVoucher;
 const lastSaleCreditWithVoucherResponsePayload =
-            "0260|00|597029414300|IM750164|123456|575354|10000|6590|34|CR|||VI|17032026|115006|" +
-            lastSaleCreditVoucher +
-            "|03|03|3334|CUOTAS SIN INTERES";
+    "0260|00|597029414300|IM750164|123456|575354|10000|6590|34|CR|||VI|17032026|115006|" +
+    lastSaleCreditVoucher +
+    "|03|03|3334|CUOTAS SIN INTERES";
 
 describe("POS Autoservicio - Debit last sale", () => {
     const suite = setupSuiteContext();
@@ -43,13 +43,33 @@ describe("POS Autoservicio - Debit last sale", () => {
         const lastSalePromise = pos.getLastSale();
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0260|00|597029414300|IM750164|123456|574062|1000|3331|56|DB|10032026|331|P |12032026|171142");
+        await sendReply(
+            pos,
+            "0260|00|597029414300|IM750164|123456|574062|1000|3331|56|DB|10032026|331|P |12032026|171142"
+        );
         const response = await lastSalePromise;
 
         expect(sentMessage).toEqual(buildMessage("0250|0"));
-        expect(response.voucher).toBeUndefined();
-        validateBaseSaleFields(response, 260, 0, "Aprobado", 597029414300, "IM750164", true);
-        validateSaleFields(response, "123456", "574062", 1000, "56", "12032026", "171142");
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
+        validateBaseSaleFields(
+            response,
+            "0260",
+            0,
+            "Aprobado",
+            597029414300,
+            "IM750164",
+            true
+        );
+        validateSaleFields(
+            response,
+            "123456",
+            "574062",
+            1000,
+            56,
+            "12032026",
+            "171142"
+        );
         validateAccountFields(response, "DB", "P ", 3331, "10032026", "331");
     });
 
@@ -70,12 +90,27 @@ describe("POS Autoservicio - Debit last sale", () => {
         ];
 
         expect(sentMessage).toEqual(buildMessage("0250|1"));
-        validateVoucherContent(response.voucher, expectedVoucherLines);
-        validateBaseSaleFields(response, 260, 0, "Aprobado", 597029414303, "IM750164", true);
-        validateSaleFields(response, "123456", "912108", 1000, "68", "19032026", "102438");
+        validateVoucherContent(response.printingField, expectedVoucherLines);
+        validateBaseSaleFields(
+            response,
+            "0260",
+            0,
+            "Aprobado",
+            597029414303,
+            "IM750164",
+            true
+        );
+        validateSaleFields(
+            response,
+            "123456",
+            "912108",
+            1000,
+            68,
+            "19032026",
+            "102438"
+        );
         validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
     });
-
 });
 
 describe("POS Autoservicio - Credit last sale", () => {
@@ -99,11 +134,27 @@ describe("POS Autoservicio - Credit last sale", () => {
         ];
 
         expect(sentMessage).toEqual(buildMessage("0250|1"));
-        validateVoucherContent(response.voucher, expectedVoucherLines);
-        validateBaseSaleFields(response, 260, 0, "Aprobado", 597029414300, "IM750164", true);
-        validateSaleFields(response, "123456", "575354", 10000, "34", "17032026", "115006");
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(response, "03", "03", "3334", "CUOTAS SIN INTERES");
+        validateVoucherContent(response.printingField, expectedVoucherLines);
+        validateBaseSaleFields(
+            response,
+            "0260",
+            0,
+            "Aprobado",
+            597029414300,
+            "IM750164",
+            true
+        );
+        validateSaleFields(
+            response,
+            "123456",
+            "575354",
+            10000,
+            34,
+            "17032026",
+            "115006"
+        );
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
     });
 
     it("last sale - approved credit without voucher", async () => {
@@ -111,15 +162,35 @@ describe("POS Autoservicio - Credit last sale", () => {
 
         const lastSalePromise = pos.getLastSale();
         const sentMessage = await captureSend(pos);
+        const posResponse =
+            "0260|00|597029414300|IM750164|123456|575354|10000|6590|34|CR|||VI|17032026|115006||03|03|3334|CUOTAS SIN INTERES";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0260|00|597029414300|IM750164|123456|575354|10000|6590|34|CR|||VI|17032026|115006||03|03|3334|CUOTAS SIN INTERES");
+        await sendReply(pos, posResponse);
         const response = await lastSalePromise;
 
         expect(sentMessage).toEqual(buildMessage("0250|0"));
-        expect(response.voucher).toBeNull();
-        validateBaseSaleFields(response, 260, 0, "Aprobado", 597029414300, "IM750164", true);
-        validateSaleFields(response, "123456", "575354", 10000, "34", "17032026", "115006");
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(response, "03", "03", "3334", "CUOTAS SIN INTERES");
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
+        expect(response.rawResponse).toEqual(posResponse);
+        validateBaseSaleFields(
+            response,
+            "0260",
+            0,
+            "Aprobado",
+            597029414300,
+            "IM750164",
+            true
+        );
+        validateSaleFields(
+            response,
+            "123456",
+            "575354",
+            10000,
+            34,
+            "17032026",
+            "115006"
+        );
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
     });
 });

--- a/tests/e2e/Autoservicio/pos.autoservicio.lastsale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.lastsale.e2e.spec.js
@@ -70,7 +70,7 @@ describe("POS Autoservicio - Debit last sale", () => {
             "12032026",
             "171142"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "10032026", "331");
+        validateAccountFields(response, "DB", "P", 3331, "10032026", "331");
     });
 
     it("last sale - approved debit with voucher", async () => {
@@ -109,7 +109,7 @@ describe("POS Autoservicio - Debit last sale", () => {
             "19032026",
             "102438"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
+        validateAccountFields(response, "DB", "P", 3331, "00-00-00", "331");
     });
 });
 

--- a/tests/e2e/Autoservicio/pos.autoservicio.multicodesale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.multicodesale.e2e.spec.js
@@ -58,13 +58,16 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
             "GRACIAS POR SU COMPRA"
         ];
 
+        expect(response.rawResponse).toBe(
+            multiCodeSaleDebitWithVoucherResponsePayload
+        );
         expect(sentMessage).toEqual(
             buildMessage("0270|1000|123456|1|0|597029414303")
         );
         validateVoucherContent(response.printingField, expectedVoucherLines);
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414303,
@@ -76,30 +79,28 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
             "123456",
             "475618",
             1000,
-            "62",
+            62,
             "18032026",
             "171040"
         );
         validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
-        expect(response.lenderCommerceCode).toBe(597012345678);
+        expect(response.commerceProviderCode).toBe(597012345678);
     });
 
     it("performs debit multicode sale and parses approved response without voucher", async () => {
         const pos = await createConnectedPos(suite);
-
+        const posResponse =
+            "0271|00|597029414303|IM750164|123456|673501|1000|3331|63|DB|00-00-00|331|P |18032026|171113|597012345678";
         const salePromise = pos.multicodeSale(1000, "123456", 597029414303);
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0271|00|597029414303|IM750164|123456|673501|1000|3331|63|DB|00-00-00|331|P |18032026|171113|597012345678"
-        );
+        await sendReply(pos, posResponse);
         const response = await salePromise;
-
+        expect(response.rawResponse).toBe(posResponse);
         expect(response.printingField).toBeNull();
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414303,
@@ -111,7 +112,7 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
             "123456",
             "673501",
             1000,
-            "63",
+            63,
             "18032026",
             "171113"
         );
@@ -119,7 +120,7 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
         expect(sentMessage).toEqual(
             buildMessage("0270|1000|123456|0|0|597029414303")
         );
-        expect(response.lenderCommerceCode).toBe(597012345678);
+        expect(response.commerceProviderCode).toBe(597012345678);
     });
 });
 
@@ -145,11 +146,13 @@ describe("POS Autoservicio - Credit multicode sale transaction", () => {
             "TIPO DE CUOTAS",
             "CUOTAS SIN INTERES"
         ];
-
+        expect(response.rawResponse).toBe(
+            multiCodeSaleCreditWithVoucherResponsePayload
+        );
         validateVoucherContent(response.printingField, expectedVoucherLines);
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414303,
@@ -161,19 +164,13 @@ describe("POS Autoservicio - Credit multicode sale transaction", () => {
             "123456",
             "194937",
             10000,
-            "64",
+            64,
             "18032026",
             "171153"
         );
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(
-            response,
-            "03",
-            "03",
-            "3334",
-            "CUOTAS SIN INTERES"
-        );
-        expect(response.lenderCommerceCode).toBe(597012345678);
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
+        expect(response.commerceProviderCode).toBe(597012345678);
         expect(sentMessage).toEqual(
             buildMessage("0270|10000|123456|1|0|597029414303")
         );
@@ -196,7 +193,7 @@ describe("POS Autoservicio - Credit multicode sale transaction", () => {
         expect(response.printingField).toBeNull();
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414303,
@@ -208,18 +205,12 @@ describe("POS Autoservicio - Credit multicode sale transaction", () => {
             "123456",
             "785992",
             10000,
-            "65",
+            65,
             "18032026",
             "171232"
         );
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(
-            response,
-            "03",
-            "03",
-            "3334",
-            "CUOTAS SIN INTERES"
-        );
-        expect(response.lenderCommerceCode).toBe(597012345678);
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
+        expect(response.commerceProviderCode).toBe(597012345678);
     });
 });

--- a/tests/e2e/Autoservicio/pos.autoservicio.multicodesale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.multicodesale.e2e.spec.js
@@ -83,7 +83,7 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
             "18032026",
             "171040"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
+        validateAccountFields(response, "DB", "P", 3331, "00-00-00", "331");
         expect(response.commerceProviderCode).toBe(597012345678);
     });
 
@@ -116,7 +116,7 @@ describe("POS Autoservicio - Debit multicode sale transaction", () => {
             "18032026",
             "171113"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
+        validateAccountFields(response, "DB", "P", 3331, "00-00-00", "331");
         expect(sentMessage).toEqual(
             buildMessage("0270|1000|123456|0|0|597029414303")
         );

--- a/tests/e2e/Autoservicio/pos.autoservicio.sale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.sale.e2e.spec.js
@@ -80,7 +80,7 @@ describe("POS Autoservicio - Debit sale transaction", () => {
             "18032026",
             "123230"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
+        validateAccountFields(response, "DB", "P", 3331, "00-00-00", "331");
     });
 
     it("performs debit sale and parses approved response without voucher", async () => {
@@ -116,7 +116,7 @@ describe("POS Autoservicio - Debit sale transaction", () => {
             "18032026",
             "123307"
         );
-        validateAccountFields(response, "DB", "P ", 3331, "00-00-00", "331");
+        validateAccountFields(response, "DB", "P", 3331, "00-00-00", "331");
     });
 });
 describe("POS Autoservicio - Credit sale transaction", () => {

--- a/tests/e2e/Autoservicio/pos.autoservicio.sale.e2e.spec.js
+++ b/tests/e2e/Autoservicio/pos.autoservicio.sale.e2e.spec.js
@@ -33,6 +33,10 @@ const saleCreditWithVoucherResponsePayload =
     "0210|00|597029414300|IM750164|123456|316557|10000|6590|57|CR|||VI|18032026|123429|" +
     saleCreditVoucher +
     "|03|03|3334|CUOTAS SIN INTERES";
+const saleDebitWithoutVoucherResponsePayload =
+    "0210|00|597029414300|IM750164|123456|700527|1000|3331|56|DB|00-00-00|331|P |18032026|123307";
+const saleCreditWithoutVoucherResponsePayload =
+    "0210|00|597029414300|IM750164|123456|776549|10000|6590|58|CR|||VI|18032026|123506||03|03|3334|CUOTAS SIN INTERES";
 
 describe("POS Autoservicio - Debit sale transaction", () => {
     const suite = setupSuiteContext();
@@ -55,10 +59,12 @@ describe("POS Autoservicio - Debit sale transaction", () => {
         ];
 
         expect(sentMessage).toEqual(buildMessage("0200|1000|123456|1|0"));
-        validateVoucherContent(response.voucher, expectedVoucherLines);
+        validateVoucherContent(response.printingField, expectedVoucherLines);
+        expect(response.rawVoucher).toBe(saleDebitVoucher);
+        expect(response.rawResponse).toBe(saleDebitWithVoucherResponsePayload);
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -70,7 +76,7 @@ describe("POS Autoservicio - Debit sale transaction", () => {
             "123456",
             "547545",
             1000,
-            "55",
+            55,
             "18032026",
             "123230"
         );
@@ -83,17 +89,18 @@ describe("POS Autoservicio - Debit sale transaction", () => {
         const salePromise = pos.sale(1000, "123456");
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0210|00|597029414300|IM750164|123456|700527|1000|3331|56|DB|00-00-00|331|P |18032026|123307"
-        );
+        await sendReply(pos, saleDebitWithoutVoucherResponsePayload);
         const response = await salePromise;
 
         expect(sentMessage).toEqual(buildMessage("0200|1000|123456|0|0"));
-        expect(response.voucher).toBeUndefined();
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
+        expect(response.rawResponse).toBe(
+            saleDebitWithoutVoucherResponsePayload
+        );
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -105,7 +112,7 @@ describe("POS Autoservicio - Debit sale transaction", () => {
             "123456",
             "700527",
             1000,
-            "56",
+            56,
             "18032026",
             "123307"
         );
@@ -134,10 +141,12 @@ describe("POS Autoservicio - Credit sale transaction", () => {
         ];
 
         expect(sentMessage).toEqual(buildMessage("0200|1000|123456|1|0"));
-        validateVoucherContent(response.voucher, expectedVoucherLines);
+        validateVoucherContent(response.printingField, expectedVoucherLines);
+        expect(response.rawVoucher).toBe(saleCreditVoucher);
+        expect(response.rawResponse).toBe(saleCreditWithVoucherResponsePayload);
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -149,18 +158,12 @@ describe("POS Autoservicio - Credit sale transaction", () => {
             "123456",
             "316557",
             10000,
-            "57",
+            57,
             "18032026",
             "123429"
         );
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(
-            response,
-            "03",
-            "03",
-            "3334",
-            "CUOTAS SIN INTERES"
-        );
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
     });
 
     it("performs credit sale and parses approved response without voucher", async () => {
@@ -169,17 +172,18 @@ describe("POS Autoservicio - Credit sale transaction", () => {
         const salePromise = pos.sale(10000, "123456");
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0210|00|597029414300|IM750164|123456|776549|10000|6590|58|CR|||VI|18032026|123506||03|03|3334|CUOTAS SIN INTERES"
-        );
+        await sendReply(pos, saleCreditWithoutVoucherResponsePayload);
         const response = await salePromise;
 
         expect(sentMessage).toEqual(buildMessage("0200|10000|123456|0|0"));
-        expect(response.voucher).toBeNull();
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
+        expect(response.rawResponse).toBe(
+            saleCreditWithoutVoucherResponsePayload
+        );
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -191,17 +195,11 @@ describe("POS Autoservicio - Credit sale transaction", () => {
             "123456",
             "776549",
             10000,
-            "58",
+            58,
             "18032026",
             "123506"
         );
-        validateAccountFields(response, "CR", "VI", 6590, "", "");
-        validateSharesFields(
-            response,
-            "03",
-            "03",
-            "3334",
-            "CUOTAS SIN INTERES"
-        );
+        validateAccountFields(response, "CR", "VI", 6590, null, null);
+        validateSharesFields(response, 3, 3, 3334, "CUOTAS SIN INTERES");
     });
 });

--- a/tests/e2e/Integrado/pos.integrado.close.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.close.e2e.spec.js
@@ -19,21 +19,22 @@ describe("POS Integrado - Close day transaction", () => {
 
     it("closes day and parses approved response", async () => {
         const pos = await createConnectedPos(suite);
-
+        const posResponse = "0510|00|597029414300|IT750050||";
         const closePromise = pos.closeDay(false);
         const sentMessage = await captureSend(pos);
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0510|00|597029414300|IT750050||");
+        await sendReply(pos, posResponse);
         const response = await closePromise;
 
         expect(sentMessage).toEqual(buildMessage("0500||"));
         expectResponseFields(response, {
-            functionCode: 510,
+            functionCode: "0510",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IT750050",
             responseMessage: "Aprobado",
-            successful: true
+            success: true,
+            rawResponse: posResponse
         });
     });
 });

--- a/tests/e2e/Integrado/pos.integrado.details.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.details.e2e.spec.js
@@ -66,7 +66,7 @@ describe("POS Integrado - Details", () => {
             "DB",
             3331,
             "000000",
-            "  ********331      "
+            "********331"
         );
         expect(firstSale.installmentsAmount).toBe(0);
         expect(firstSale.installmentsNumber).toBe(0);

--- a/tests/e2e/Integrado/pos.integrado.lastsale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.lastsale.e2e.spec.js
@@ -57,7 +57,7 @@ describe("POS Integrado - Last Sale with transactions", () => {
             "DB",
             3331,
             "000000",
-            "  ********331      "
+            "********331"
         );
         expect(response.employeeId).toBe(null);
         expect(response.tip).toBe(null);

--- a/tests/e2e/Integrado/pos.integrado.lastsale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.lastsale.e2e.spec.js
@@ -25,13 +25,13 @@ describe("POS Integrado - Last Sale with transactions", () => {
         const pos = await createConnectedPos(suite);
         const lastSalePromise = pos.getLastSale();
         const sentMessage = await captureSend(pos);
+        const posResponse =
+            "0260|00|597029414300|IT750050|ABC123|875395|1000|00|0|3331|000140|DB|000000|  ********331      |DB|03032026|093106||||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0260|00|597029414300|IT750050|ABC123|875395|1000|00|0|3331|000140|DB|000000|  ********331      |DB|03032026|093106||||"
-        );
+        await sendReply(pos, posResponse);
         const response = await lastSalePromise;
 
+        expect(response.rawResponse).toEqual(posResponse);
         expect(sentMessage).toEqual(buildMessage("0250|"));
         validateBaseSaleFields(
             response,
@@ -67,13 +67,13 @@ describe("POS Integrado - Last Sale with transactions", () => {
         const pos = await createConnectedPos(suite);
         const lastSalePromise = pos.getLastSale();
         const sentMessage = await captureSend(pos);
+        const posResponse =
+            "0260|00|597029414300|IT750050|ABC123|794160|12000|03|4000|6590|000141|CR|003000|3000000000000000000|VI|06042026|234109||||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0260|00|597029414300|IT750050|ABC123|794160|12000|03|4000|6590|000141|CR|003000|3000000000000000000|VI|06042026|234109||||"
-        );
+        await sendReply(pos, posResponse);
         const response = await lastSalePromise;
 
+        expect(response.rawResponse).toEqual(posResponse);
         expect(sentMessage).toEqual(buildMessage("0250|"));
         validateBaseSaleFields(
             response,
@@ -113,10 +113,12 @@ describe("POS Integrado - Last Sale without transactions", () => {
         const pos = await createConnectedPos(suite);
         const lastSalePromise = pos.getLastSale();
         const sentMessage = await captureSend(pos);
+        const posResponse = "0260|11|||||||||||||||||||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0260|11|||||||||||||||||||");
+        await sendReply(pos, posResponse);
         const response = await lastSalePromise;
 
+        expect(response.rawResponse).toEqual(posResponse);
         expect(sentMessage).toEqual(buildMessage("0250|"));
         validateBaseSaleFields(
             response,

--- a/tests/e2e/Integrado/pos.integrado.multicodesale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.multicodesale.e2e.spec.js
@@ -78,13 +78,20 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
         await sendReply(pos, multiCodeSaleDebitWithVoucherResponsePayload);
         const response = await salePromise;
 
+        expect(response.rawResponse).toBe(
+            multiCodeSaleDebitWithVoucherResponsePayload
+        );
+        expect(response.rawVoucher).toBe(multiCodeSaleDebitVoucher);
         expect(sentMessage).toEqual(
             buildMessage("0270|8000|ABC123||1|0|597029414303|")
         );
-        validateVoucherContent(response.voucher, debitVoucherExpectedLines);
+        validateVoucherContent(
+            response.printingField,
+            debitVoucherExpectedLines
+        );
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414300,
@@ -96,7 +103,7 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "ABC123",
             "708410",
             8000,
-            "000143",
+            143,
             "07042026",
             "085034"
         );
@@ -108,7 +115,7 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "000000",
             "  ********331      "
         );
-        expect(response.lenderCommerceCode).toBe(597029414303);
+        expect(response.commerceProviderCode).toBe(597029414303);
     });
 
     it("performs debit multicode sale and parses approved response without voucher", async () => {
@@ -124,10 +131,14 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
         await sendReply(pos, ACK_BYTE);
         await sendReply(pos, multiCodeSaleDebitWithoutVoucherResponsePayload);
         const response = await salePromise;
-        expect(response.voucher).toBeNull();
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
+        expect(response.rawResponse).toBe(
+            multiCodeSaleDebitWithoutVoucherResponsePayload
+        );
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414300,
@@ -139,7 +150,7 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "ABC123",
             "388892",
             7000,
-            "000144",
+            144,
             "07042026",
             "085628"
         );
@@ -151,7 +162,7 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "000000",
             "  ********331      "
         );
-        expect(response.lenderCommerceCode).toBe(597029414303);
+        expect(response.commerceProviderCode).toBe(597029414303);
         expect(sentMessage).toEqual(
             buildMessage("0270|7000|ABC123||0|0|597029414303|")
         );
@@ -177,11 +188,16 @@ describe("POS Integrado - Cancelled transaction", () => {
         expect(sentMessage).toEqual(
             buildMessage("0270|90000|ABC123||1|0|597029414303|")
         );
+        expect(response.rawResponse).toBe(
+            multiCodeSaleCancelledResponsePayload
+        );
         expect(response.responseCode).toBe(7);
         expect(response.responseMessage).toBe(
             "Transacción Cancelada desde el POS"
         );
-        expect(response.successful).toBe(false);
+        expect(response.success).toBe(false);
+        expect(response.rawVoucher).toBeNull();
+        expect(response.printingField).toBeNull();
     });
 });
 
@@ -202,10 +218,17 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
         await sendReply(pos, multiCodeSaleCreditWithVoucherResponsePayload);
         const response = await salePromise;
 
-        validateVoucherContent(response.voucher, creditVoucherExpectedLines);
+        expect(response.rawResponse).toBe(
+            multiCodeSaleCreditWithVoucherResponsePayload
+        );
+        expect(response.rawVoucher).toBe(multiCodeSaleCreditVoucher);
+        validateVoucherContent(
+            response.printingField,
+            creditVoucherExpectedLines
+        );
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414300,
@@ -217,7 +240,7 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
             "ABC123",
             "794160",
             12000,
-            "000141",
+            141,
             "06042026",
             "234109"
         );
@@ -229,9 +252,9 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
             "003000",
             "3000000000000000000"
         );
-        expect(response.sharesNumber).toBe("03");
-        expect(response.sharesAmount).toBe("4000");
-        expect(response.lenderCommerceCode).toBe(597029414303);
+        expect(response.installmentsNumber).toBe(3);
+        expect(response.installmentsAmount).toBe(4000);
+        expect(response.commerceProviderCode).toBe(597029414303);
         expect(sentMessage).toEqual(
             buildMessage("0270|12000|ABC123||1|0|597029414303|")
         );
@@ -251,10 +274,14 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
         await sendReply(pos, multiCodeSaleCreditWithoutVoucherResponsePayload);
         const response = await salePromise;
 
-        expect(response.voucher).toBeNull();
+        expect(response.rawResponse).toBe(
+            multiCodeSaleCreditWithoutVoucherResponsePayload
+        );
+        expect(response.rawVoucher).toBeNull();
+        expect(response.printingField).toBeNull();
         validateBaseSaleFields(
             response,
-            271,
+            "0271",
             0,
             "Aprobado",
             597029414300,
@@ -266,7 +293,7 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
             "ABC123",
             "162529",
             9000,
-            "000142",
+            142,
             "07042026",
             "084918"
         );
@@ -278,9 +305,9 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
             "003000",
             "3000000000000000000"
         );
-        expect(response.sharesNumber).toBe("03");
-        expect(response.sharesAmount).toBe("3000");
-        expect(response.lenderCommerceCode).toBe(597029414303);
+        expect(response.installmentsNumber).toBe(3);
+        expect(response.installmentsAmount).toBe(3000);
+        expect(response.commerceProviderCode).toBe(597029414303);
         expect(sentMessage).toEqual(
             buildMessage("0270|9000|ABC123||0|0|597029414303|")
         );

--- a/tests/e2e/Integrado/pos.integrado.multicodesale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.multicodesale.e2e.spec.js
@@ -61,7 +61,7 @@ const creditVoucherExpectedLines = [
     "OPERACION: 000141   AUTORIZACION: 794160"
 ];
 
-describe("POS Integrado - Debit multicode sale transaction", () => {
+describe("POS Integrado - Debit multicode sale transaction - voucher", () => {
     const suite = setupSuiteContext();
 
     it("performs debit multicode sale and parses approved response with voucher", async () => {
@@ -113,10 +113,14 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "DB",
             3331,
             "000000",
-            "  ********331      "
+            "********331"
         );
         expect(response.commerceProviderCode).toBe(597029414303);
     });
+});
+
+describe("POS Integrado - Debit multicode sale transaction", () => {
+    const suite = setupSuiteContext();
 
     it("performs debit multicode sale and parses approved response without voucher", async () => {
         const pos = await createConnectedPos(suite);
@@ -160,7 +164,7 @@ describe("POS Integrado - Debit multicode sale transaction", () => {
             "DB",
             3331,
             "000000",
-            "  ********331      "
+            "********331"
         );
         expect(response.commerceProviderCode).toBe(597029414303);
         expect(sentMessage).toEqual(
@@ -201,7 +205,7 @@ describe("POS Integrado - Cancelled transaction", () => {
     });
 });
 
-describe("POS Integrado - Credit multicode sale transaction", () => {
+describe("POS Integrado - Credit multicode sale transaction - voucher", () => {
     const suite = setupSuiteContext();
 
     it("performs credit multicode sale and parses approved response with voucher", async () => {
@@ -259,6 +263,10 @@ describe("POS Integrado - Credit multicode sale transaction", () => {
             buildMessage("0270|12000|ABC123||1|0|597029414303|")
         );
     });
+});
+
+describe("POS Integrado - Credit multicode sale transaction", () => {
+    const suite = setupSuiteContext();
 
     it("performs credit multicode sale and parses approved response without voucher", async () => {
         const pos = await createConnectedPos(suite);

--- a/tests/e2e/Integrado/pos.integrado.refund.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.refund.e2e.spec.js
@@ -21,19 +21,21 @@ describe("POS Integrado - Refund", () => {
         const pos = await createConnectedPos(suite);
         const refundPromise = pos.refund(143);
         const sentMessage = await captureSend(pos);
+        const posResponse = "1210|21|597029414300|IT750050||143||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "1210|21|597029414300|IT750050||143||");
+        await sendReply(pos, posResponse);
         const response = await refundPromise;
         expect(sentMessage).toEqual(buildMessage("1200|143|"));
+        expect(response.rawResponse).toEqual(posResponse);
         expectResponseFields(response, {
-            functionCode: 1210,
+            functionCode: "1210",
             responseCode: 21,
             commerceCode: 597029414300,
             terminalId: "IT750050",
-            authorizationCode: "",
-            operationId: "143",
+            authorizationCode: null,
+            operationId: 143,
             responseMessage: "Anulación no Permitida",
-            successful: false
+            success: false
         });
     });
 
@@ -41,19 +43,21 @@ describe("POS Integrado - Refund", () => {
         const pos = await createConnectedPos(suite);
         const refundPromise = pos.refund(142);
         const sentMessage = await captureSend(pos);
+        const posResponse = "1210|00|597029414300|IT750050|162529|000142||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "1210|00|597029414300|IT750050|162529|000142||");
+        await sendReply(pos, posResponse);
         const response = await refundPromise;
+        expect(response.rawResponse).toEqual(posResponse);
         expect(sentMessage).toEqual(buildMessage("1200|142|"));
         expectResponseFields(response, {
-            functionCode: 1210,
+            functionCode: "1210",
             responseCode: 0,
             commerceCode: 597029414300,
             terminalId: "IT750050",
             authorizationCode: "162529",
-            operationId: "000142",
+            operationId: 142,
             responseMessage: "Aprobado",
-            successful: true
+            success: true
         });
     });
 });

--- a/tests/e2e/Integrado/pos.integrado.sale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.sale.e2e.spec.js
@@ -24,10 +24,22 @@ const createConnectedPos = async (suite) => {
     return pos;
 };
 
+const expectedVoucherLines = [
+    "MONTO VENTA:                     $32.773",
+    "           RUT: 11.111.111-1            ",
+    "OPERACION: 000156   AUTORIZACION: 532264"
+];
+
 const normalSaleCreditWithVoucherResponsePayload =
     "0210|00|597029414300|IT750870|ABC123|532264|39000|00||6590|000156|CR|000000|3000000000000000000|VI|07052026|161140||0|" +
     normalSaleCreditVoucher +
     "|";
+
+const normalSaleWithOutVoucherResponsePayload =
+    "0210|00|597029414300|IT750870|ABC123|144809|35000|03|11668|6590|000155|CR|003000|3000000000000000000|VI|07052026|152829||0||";
+
+const canceledSaleResponsePayload =
+    "0210|07|597029414300|IT750870|ABC123||80000||||||||||||||";
 
 describe("POS Integrado - Normal sale transaction", () => {
     const suite = setupSuiteContext();
@@ -38,12 +50,6 @@ describe("POS Integrado - Normal sale transaction", () => {
         await sendReply(pos, ACK_BYTE);
         await sendReply(pos, normalSaleCreditWithVoucherResponsePayload);
         const response = await salePromise;
-        const expectedVoucherLines = [
-            "MONTO VENTA:                     $32.773",
-            "           RUT: 11.111.111-1            ",
-            "OPERACION: 000156   AUTORIZACION: 532264"
-        ];
-
         expect(response.rawResponse).toBe(
             normalSaleCreditWithVoucherResponsePayload
         );
@@ -82,13 +88,12 @@ describe("POS Integrado - Normal sale transaction", () => {
         const pos = await createConnectedPos(suite);
         const salePromise = pos.sale(35000, "ABC123", false, false);
         const sentMessage = await captureSend(pos);
-        const posResponse =
-            "0210|00|597029414300|IT750870|ABC123|144809|35000|03|11668|6590|000155|CR|003000|3000000000000000000|VI|07052026|152829||0||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, posResponse);
+        await sendReply(pos, normalSaleWithOutVoucherResponsePayload);
         const response = await salePromise;
-
-        expect(response.rawResponse).toBe(posResponse);
+        expect(response.rawResponse).toBe(
+            normalSaleWithOutVoucherResponsePayload
+        );
         expect(response.printingField).toBeNull();
         expect(response.rawVoucher).toBeNull();
         expect(sentMessage).toEqual(buildMessage("0200|35000|ABC123||0|0"));
@@ -124,13 +129,10 @@ describe("POS Integrado - Normal sale transaction", () => {
         const pos = await createConnectedPos(suite);
         const salePromise = pos.sale(80000, "ABC123", false, true);
         const sentMessage = await captureSend(pos);
-        const posResponse =
-            "0210|07|597029414300|IT750870|ABC123||80000||||||||||||||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, posResponse);
+        await sendReply(pos, canceledSaleResponsePayload);
         const response = await salePromise;
-
-        expect(response.rawResponse).toBe(posResponse);
+        expect(response.rawResponse).toBe(canceledSaleResponsePayload);
         expect(response.printingField).toBeNull();
         expect(response.rawVoucher).toBeNull();
         expect(sentMessage).toEqual(buildMessage("0200|80000|ABC123||1|0"));

--- a/tests/e2e/Integrado/pos.integrado.sale.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.sale.e2e.spec.js
@@ -44,11 +44,15 @@ describe("POS Integrado - Normal sale transaction", () => {
             "OPERACION: 000156   AUTORIZACION: 532264"
         ];
 
-        validateVoucherContent(response.voucher, expectedVoucherLines);
+        expect(response.rawResponse).toBe(
+            normalSaleCreditWithVoucherResponsePayload
+        );
+        expect(response.rawVoucher).toBe(normalSaleCreditVoucher);
+        validateVoucherContent(response.printingField, expectedVoucherLines);
         expect(sentMessage).toEqual(buildMessage("0200|39000|ABC123||1|0"));
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -60,7 +64,7 @@ describe("POS Integrado - Normal sale transaction", () => {
             "ABC123",
             "532264",
             39000,
-            "000156",
+            156,
             "07052026",
             "161140"
         );
@@ -78,18 +82,19 @@ describe("POS Integrado - Normal sale transaction", () => {
         const pos = await createConnectedPos(suite);
         const salePromise = pos.sale(35000, "ABC123", false, false);
         const sentMessage = await captureSend(pos);
+        const posResponse =
+            "0210|00|597029414300|IT750870|ABC123|144809|35000|03|11668|6590|000155|CR|003000|3000000000000000000|VI|07052026|152829||0||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0210|00|597029414300|IT750870|ABC123|144809|35000|03|11668|6590|000155|CR|003000|3000000000000000000|VI|07052026|152829||0||"
-        );
+        await sendReply(pos, posResponse);
         const response = await salePromise;
 
-        expect(response.voucher).toBeNull();
+        expect(response.rawResponse).toBe(posResponse);
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
         expect(sentMessage).toEqual(buildMessage("0200|35000|ABC123||0|0"));
         validateBaseSaleFields(
             response,
-            210,
+            "0210",
             0,
             "Aprobado",
             597029414300,
@@ -101,7 +106,7 @@ describe("POS Integrado - Normal sale transaction", () => {
             "ABC123",
             "144809",
             35000,
-            "000155",
+            155,
             "07052026",
             "152829"
         );
@@ -119,14 +124,15 @@ describe("POS Integrado - Normal sale transaction", () => {
         const pos = await createConnectedPos(suite);
         const salePromise = pos.sale(80000, "ABC123", false, true);
         const sentMessage = await captureSend(pos);
+        const posResponse =
+            "0210|07|597029414300|IT750870|ABC123||80000||||||||||||||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(
-            pos,
-            "0210|07|597029414300|IT750870|ABC123||80000||||||||||||||"
-        );
+        await sendReply(pos, posResponse);
         const response = await salePromise;
 
-        expect(response.voucher).toBeNull();
+        expect(response.rawResponse).toBe(posResponse);
+        expect(response.printingField).toBeNull();
+        expect(response.rawVoucher).toBeNull();
         expect(sentMessage).toEqual(buildMessage("0200|80000|ABC123||1|0"));
     });
 });

--- a/tests/e2e/Integrado/pos.integrado.totals.e2e.spec.js
+++ b/tests/e2e/Integrado/pos.integrado.totals.e2e.spec.js
@@ -21,17 +21,19 @@ describe("POS Integrado - Totals", () => {
 
         const totalsPromise = pos.getTotals();
         const sentMessage = await captureSend(pos);
+        const posResponse = "0710|00|002|15000||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0710|00|002|15000||");
+        await sendReply(pos, posResponse);
         expect(sentMessage).toEqual(buildMessage("0700||"));
         const response = await totalsPromise;
         expect(response).toEqual({
-            functionCode: 710,
+            functionCode: "0710",
             responseCode: 0,
             txCount: 2,
             txTotal: 15000,
             responseMessage: "Aprobado",
-            successful: true
+            success: true,
+            rawResponse: posResponse
         });
     });
 
@@ -40,17 +42,19 @@ describe("POS Integrado - Totals", () => {
 
         const totalsPromise = pos.getTotals();
         const sentMessage = await captureSend(pos);
+        const posResponse = "0710|00|000|0||";
         await sendReply(pos, ACK_BYTE);
-        await sendReply(pos, "0710|00|000|||");
+        await sendReply(pos, posResponse);
         expect(sentMessage).toEqual(buildMessage("0700||"));
         const response = await totalsPromise;
         expect(response).toEqual({
-            functionCode: 710,
+            functionCode: "0710",
             responseCode: 0,
             txCount: 0,
-            txTotal: null,
+            txTotal: 0,
             responseMessage: "Aprobado",
-            successful: true
+            success: true,
+            rawResponse: posResponse
         });
     });
 });

--- a/tests/e2e/helpers/validationHelpers.js
+++ b/tests/e2e/helpers/validationHelpers.js
@@ -47,13 +47,13 @@ const validateSharesFields = (
     installmentsType,
     installmentsNumber,
     installmentsAmount,
-    InstallmentsTypeDescription
+    installmentsTypeDescription
 ) => {
     expectResponseFields(response, {
         installmentsType: installmentsType,
         installmentsNumber: installmentsNumber,
         installmentsAmount: installmentsAmount,
-        InstallmentsTypeDescription: InstallmentsTypeDescription
+        installmentsTypeDescription: installmentsTypeDescription
     });
 };
 

--- a/tests/e2e/helpers/validationHelpers.js
+++ b/tests/e2e/helpers/validationHelpers.js
@@ -11,7 +11,7 @@ const validateBaseSaleFields = (
     responseMessage,
     commerceCode,
     terminalId,
-    successful
+    success
 ) => {
     expectResponseFields(response, {
         functionCode: functionCode,
@@ -19,7 +19,7 @@ const validateBaseSaleFields = (
         responseMessage: responseMessage,
         commerceCode: commerceCode,
         terminalId: terminalId,
-        successful: successful
+        success: success
     });
 };
 
@@ -44,16 +44,16 @@ const validateSaleFields = (
 
 const validateSharesFields = (
     response,
-    sharesType,
-    sharesNumber,
-    sharesAmount,
-    sharesTypeGloss
+    installmentsType,
+    installmentsNumber,
+    installmentsAmount,
+    InstallmentsTypeDescription
 ) => {
     expectResponseFields(response, {
-        sharesType: sharesType,
-        sharesNumber: sharesNumber,
-        sharesAmount: sharesAmount,
-        sharesTypeGloss: sharesTypeGloss
+        installmentsType: installmentsType,
+        installmentsNumber: installmentsNumber,
+        installmentsAmount: installmentsAmount,
+        InstallmentsTypeDescription: InstallmentsTypeDescription
     });
 };
 
@@ -75,8 +75,8 @@ const validateAccountFields = (
 };
 
 const validateVoucherContent = (voucher, expectedLines) => {
-    expect(voucher.every(line => line.length === 40)).toBe(true);
-    const voucherText = voucher.join('\n');
+    expect(voucher.every((line) => line.length === 40)).toBe(true);
+    const voucherText = voucher.join("\n");
     expectedLines.forEach((expectedLine) => {
         expect(voucherText).toContain(expectedLine);
     });

--- a/tests/e2e/shared/posBase.shared.js
+++ b/tests/e2e/shared/posBase.shared.js
@@ -44,21 +44,20 @@ const describePosBaseTests = ({ createPos }) => {
             const pos = await createConnectedPos(createPos);
             const loadKeysPromise = pos.loadKeys();
             const sentMessage = await captureSend(pos);
+            const posReply = `0810|00|${COMMERCE_CODE}|${TERMINAL_ID}`;
             await sendReply(pos, ACK_BYTE);
-            await sendReply(
-                pos,
-                `0810|00|${COMMERCE_CODE}|${TERMINAL_ID}`
-            );
+            await sendReply(pos, posReply);
             const response = await loadKeysPromise;
 
             expect(sentMessage).toEqual(buildMessage("0800"));
             expectResponseFields(response, {
-                functionCode: 810,
+                functionCode: "0810",
                 responseCode: 0,
                 commerceCode: COMMERCE_CODE,
                 terminalId: TERMINAL_ID,
                 responseMessage: "Aprobado",
-                successful: true
+                success: true,
+                rawResponse: posReply
             });
         });
 
@@ -66,21 +65,20 @@ const describePosBaseTests = ({ createPos }) => {
             const pos = await createConnectedPos(createPos);
             const loadKeysPromise = pos.loadKeys();
             const sentMessage = await captureSend(pos);
+            const posReply = `0810|01|${COMMERCE_CODE}|${TERMINAL_ID}`;
             await sendReply(pos, ACK_BYTE);
-            await sendReply(
-                pos,
-                `0810|01|${COMMERCE_CODE}|${TERMINAL_ID}`
-            );
+            await sendReply(pos, posReply);
             const response = await loadKeysPromise;
 
             expect(sentMessage).toEqual(buildMessage("0800"));
             expectResponseFields(response, {
-                functionCode: 810,
+                functionCode: "0810",
                 responseCode: 1,
                 commerceCode: COMMERCE_CODE,
                 terminalId: TERMINAL_ID,
                 responseMessage: "Rechazado",
-                successful: false
+                success: false,
+                rawResponse: posReply
             });
         });
     });

--- a/tests/unit/helpers/fieldParser.spec.js
+++ b/tests/unit/helpers/fieldParser.spec.js
@@ -8,12 +8,25 @@ describe("normalizeEmptyField", () => {
         expect(normalizeEmptyField(undefined)).toBeNull();
         expect(normalizeEmptyField(null)).toBeNull();
         expect(normalizeEmptyField("")).toBeNull();
+        expect(normalizeEmptyField("   ")).toBeNull();
     });
 
-    it("returns string values without trimming spaces", () => {
+    it("returns trimmed string values by default", () => {
         expect(normalizeEmptyField("ABC123")).toBe("ABC123");
-        expect(normalizeEmptyField("  ********331      ")).toBe("  ********331      ");
-        expect(normalizeEmptyField("P ")).toBe("P ");
+        expect(normalizeEmptyField("  ********331      ")).toBe("********331");
+        expect(normalizeEmptyField("P ")).toBe("P");
+        expect(normalizeEmptyField("  hello world  ")).toBe("hello world");
+    });
+
+    it("returns untrimmed string values when trim is false", () => {
+        expect(normalizeEmptyField("ABC123", false)).toBe("ABC123");
+        expect(normalizeEmptyField("  ********331      ", false)).toBe(
+            "  ********331      "
+        );
+        expect(normalizeEmptyField("P ", false)).toBe("P ");
+        expect(normalizeEmptyField("  hello world  ", false)).toBe(
+            "  hello world  "
+        );
     });
 });
 


### PR DESCRIPTION
This PR normalize SDK responses.
Now empty fields return null.
Field names are standardized across responses.
Now are returned a rawResponse and rawVoucher fields.